### PR TITLE
lists.less: Adjust caption font size for list-items

### DIFF
--- a/public/css/lists.less
+++ b/public/css/lists.less
@@ -91,9 +91,15 @@
     p {
       display: inline-block;
     }
+
+    &.plugin-output, .plugin-output {
+      font-size: 11/12em;
+      line-height: 1.5*12/11em;
+    }
   }
 
   header {
+    align-items: baseline;
     display: flex;
     justify-content: space-between;
 


### PR DESCRIPTION
The font sizes of list item output preview in the original monitoring module is a little smaller than in the current module.

I thought it would be a bad idea since it makes the eye focus more on the headings. and looks a little cleaner.


## Original Icinga monitoring module

![Screenshot 2020-03-17 at 16 41 59](https://user-images.githubusercontent.com/6977434/76873848-9ee94380-686e-11ea-97c4-8cdba75249d0.png)

## Current

![Screenshot 2020-03-17 at 17 02 51](https://user-images.githubusercontent.com/6977434/76875670-2a63d400-6871-11ea-9a6c-1d0c5077e758.png)



