### PR TITLE
Change instance sort order to prefer rows with responsible='y'

### DIFF
--- a/library/Icingadb/Model/Instance.php
+++ b/library/Icingadb/Model/Instance.php
@@ -42,7 +42,7 @@ class Instance extends Model
 
     public function getDefaultSort()
     {
-        return 'responsible desc';
+        return 'responsible asc';
     }
 
     public function createBehaviors(Behaviors $behaviors)


### PR DESCRIPTION
Due to the column type of `responsible` being `enum('y', 'n')`, `'y'` is consideres to be less than `'n'` and ascending sort is needed to prefer the row of the responsible instance.

This change is needed as we are planning to have one row per running Icinga DB process so it will become important that the web module selects the correct row (until now there's only one).

refs https://github.com/Icinga/icingadb/pull/232 https://github.com/Icinga/icingadb/issues/234