### PR TITLE
Re-add host tabs to service detail

### DIFF
--- a/application/controllers/ServiceController.php
+++ b/application/controllers/ServiceController.php
@@ -6,6 +6,7 @@ namespace Icinga\Module\Icingadb\Controllers;
 
 use Icinga\Exception\NotFoundError;
 use Icinga\Module\Icingadb\Common\CommandActions;
+use Icinga\Module\Icingadb\Common\HostLinks;
 use Icinga\Module\Icingadb\Common\Links;
 use Icinga\Module\Icingadb\Common\ServiceLinks;
 use Icinga\Module\Icingadb\Model\History;
@@ -192,9 +193,17 @@ class ServiceController extends Controller
     {
         return $this
             ->getTabs()
+            ->add('host', [
+                'label'  => t('Host'),
+                'url'    => Links::host($this->service->host, $this->service)
+            ])
             ->add('index', [
                 'label'  => t('Service'),
                 'url'    => Links::service($this->service, $this->service->host)
+            ])
+            ->add('services', [
+                'label'  => t('Services'),
+                'url'    => HostLinks::services($this->service->host, $this->service)
             ])
             ->add('history', [
                 'label'  => t('History'),

--- a/library/Icingadb/Common/HostLinks.php
+++ b/library/Icingadb/Common/HostLinks.php
@@ -5,6 +5,7 @@
 namespace Icinga\Module\Icingadb\Common;
 
 use Icinga\Module\Icingadb\Model\Host;
+use Icinga\Module\Icingadb\Model\Service;
 use ipl\Web\Url;
 
 abstract class HostLinks
@@ -69,8 +70,13 @@ abstract class HostLinks
         return Url::fromPath('icingadb/host/toggle-features', ['name' => $host->name]);
     }
 
-    public static function services(Host $host)
+    public static function services(Host $host, Service $service = null)
     {
-        return Url::fromPath('icingadb/host/services', ['name' => $host->name]);
+        $url = Url::fromPath('icingadb/host/services', ['name' => $host->name]);
+        if ($service !== null) {
+            $url->addParams(['service.name' => $service->name]);
+        }
+
+        return $url;
     }
 }

--- a/library/Icingadb/Common/Links.php
+++ b/library/Icingadb/Common/Links.php
@@ -56,9 +56,14 @@ abstract class Links
         return Url::fromPath('icingadb/downtimes/details');
     }
 
-    public static function host(Host $host)
+    public static function host(Host $host, Service $service = null)
     {
-        return Url::fromPath('icingadb/host', ['name' => $host->name]);
+        $url = Url::fromPath('icingadb/host', ['name' => $host->name]);
+        if ($service !== null) {
+            $url->addParams(['service.name' => $service->name]);
+        }
+
+        return $url;
     }
 
     public static function hostsDetails()


### PR DESCRIPTION
![Screenshot from 2021-05-07 15-42-49](https://user-images.githubusercontent.com/16668527/117458757-ec30e480-af4a-11eb-8744-757d7122b0b7.png)

When in service detail view, the `Host` and `Services` tabs are displayed now. This is now the same as in the monitoring module, with a single exception:

* The `History` tab doesn't change its context anymore
  * Clicking on `Host` while looking at a service and then clicking on `History` will show the service history, **not** the host history
  * This means that there is no click-path from the service detail view to the host's history in any way
  * I did this as I think the tabs should all keep their context if they happen to have multiple meanings
    * Splitting the `History` into `Host History` and `Service History` is another solution, but that's too much tabs then, right?

Also, what I'm unsure of is whether we should show the `Services` tab when in service context:

a) Keep it as is now (i.e. The `Services` tab is always there)
b) Only show the `Services` tab when in host context, hide it completely in service context

@lippserd, @flourish86 Please share your thoughts regarding the `History` and `Services` tab behavior

resolves #115