### PR TITLE
Instance: Don't change behavior of the `icinga2_start_time` property

### DIFF
--- a/library/Icingadb/Model/Instance.php
+++ b/library/Icingadb/Model/Instance.php
@@ -47,10 +47,7 @@ class Instance extends Model
 
     public function createBehaviors(Behaviors $behaviors)
     {
-        $behaviors->add(new Timestamp([
-            'heartbeat',
-            'icinga2_start_time'
-        ]));
+        $behaviors->add(new Timestamp(['heartbeat']));
         $behaviors->add(new BoolCast([
             'responsible',
             'icinga2_active_host_checks_enabled',


### PR DESCRIPTION
Since `icingadb` is storing the timestamp values in seconds, it is
quite unnecessary to simplyfy them by `1000.0` again, which yielded
an incorrect results.