### PR TITLE
The Services tab in the host detail view throws an error if a service contains a comment

### DIFF
--- a/application/controllers/HostController.php
+++ b/application/controllers/HostController.php
@@ -170,6 +170,7 @@ class HostController extends Controller
 
         $services = Service::on($db)->with([
             'state',
+            'state.last_comment',
             'icon_image',
             'host',
             'host.state'


### PR DESCRIPTION
fix #278 