### PR TITLE
Don't shift URL params to identify objects in detail views

### DIFF
--- a/application/controllers/CommentController.php
+++ b/application/controllers/CommentController.php
@@ -23,7 +23,7 @@ class CommentController extends Controller
     {
         $this->setTitle(t('Comment'));
 
-        $name = $this->params->shiftRequired('name');
+        $name = $this->params->getRequired('name');
 
         $query = Comment::on($this->getDb())->with([
             'host',

--- a/application/controllers/DowntimeController.php
+++ b/application/controllers/DowntimeController.php
@@ -23,7 +23,7 @@ class DowntimeController extends Controller
     {
         $this->setTitle(t('Downtime'));
 
-        $name = $this->params->shiftRequired('name');
+        $name = $this->params->getRequired('name');
 
         $query = Downtime::on($this->getDb())->with([
             'host',

--- a/application/controllers/EventController.php
+++ b/application/controllers/EventController.php
@@ -21,7 +21,7 @@ class EventController extends Controller
     {
         $this->setTitle(t('Event'));
 
-        $id = $this->params->shiftRequired('id');
+        $id = $this->params->getRequired('id');
 
         $query = History::on($this->getDb())
             ->with([

--- a/application/controllers/HostController.php
+++ b/application/controllers/HostController.php
@@ -34,7 +34,7 @@ class HostController extends Controller
 
     public function init()
     {
-        $name = $this->params->shiftRequired('name');
+        $name = $this->params->getRequired('name');
 
         $query = Host::on($this->getDb())->with(['state', 'icon_image']);
         $query->getSelectBase()

--- a/application/controllers/HostgroupController.php
+++ b/application/controllers/HostgroupController.php
@@ -23,7 +23,7 @@ class HostgroupController extends Controller
 
         $this->setTitle(t('Host Group'));
 
-        $name = $this->params->shiftRequired('name');
+        $name = $this->params->getRequired('name');
 
         $query = Hostgroupsummary::on($this->getDb());
 

--- a/application/controllers/ServiceController.php
+++ b/application/controllers/ServiceController.php
@@ -30,8 +30,8 @@ class ServiceController extends Controller
 
     public function init()
     {
-        $name = $this->params->shiftRequired('name');
-        $hostName = $this->params->shiftRequired('host.name');
+        $name = $this->params->getRequired('name');
+        $hostName = $this->params->getRequired('host.name');
 
         $query = Service::on($this->getDb())->with([
             'state',

--- a/application/controllers/ServicegroupController.php
+++ b/application/controllers/ServicegroupController.php
@@ -23,7 +23,7 @@ class ServicegroupController extends Controller
 
         $this->setTitle(t('Service Group'));
 
-        $name = $this->params->shiftRequired('name');
+        $name = $this->params->getRequired('name');
 
         $query = ServicegroupSummary::on($this->getDb());
 

--- a/application/controllers/UserController.php
+++ b/application/controllers/UserController.php
@@ -21,7 +21,7 @@ class UserController extends Controller
 
         $this->setTitle(t('User'));
 
-        $name = $this->params->shiftRequired('name');
+        $name = $this->params->getRequired('name');
 
         $query = User::on($this->getDb());
         $query->getSelectBase()

--- a/application/controllers/UsergroupController.php
+++ b/application/controllers/UsergroupController.php
@@ -21,7 +21,7 @@ class UsergroupController extends Controller
 
         $this->setTitle(t('User Group'));
 
-        $name = $this->params->shiftRequired('name');
+        $name = $this->params->getRequired('name');
 
         $query = Usergroup::on($this->getDb());
         $query->getSelectBase()


### PR DESCRIPTION
Parameters used to identify what will be shown need to be preserved. Just like it's done for filters in lists.

refs #299
refs #312