### PR TITLE
Controller: Reset all params on form change

### DIFF
--- a/library/Icingadb/Web/Controller.php
+++ b/library/Icingadb/Web/Controller.php
@@ -154,7 +154,9 @@ class Controller extends CompatController
     public function createSearchBar(Query $query, array $preserveParams = null)
     {
         $requestUrl = Url::fromRequest();
-        $redirectUrl = $preserveParams !== null ? $requestUrl->onlyWith($preserveParams) : $requestUrl;
+        $redirectUrl = $preserveParams !== null
+            ? $requestUrl->onlyWith($preserveParams)
+            : (clone $requestUrl)->setParams([]);
 
         $filter = QueryString::fromString((string) $this->params)
             ->on(QueryString::ON_CONDITION, function (Filter\Condition $condition) use ($query) {


### PR DESCRIPTION
The problem here was all the parameters added by the search-bar could never be deleted again as
the tactical overview doesn't provide any preserved params that could reset this filter.
This PR fixes that by simply removing all parameters from the URL being redirected when the trash icon is pressed.

resolves #318 