### PR TITLE
Store redis connections in a separate file

### DIFF
--- a/library/Icingadb/Common/IcingaRedis.php
+++ b/library/Icingadb/Common/IcingaRedis.php
@@ -90,32 +90,40 @@ trait IcingaRedis
         return null;
     }
 
-    public function getPrimaryRedis(Config $config = null)
+    public function getPrimaryRedis(Config $moduleConfig = null, Config $redisConfig = null)
     {
-        if ($config === null) {
-            $config = Config::module('icingadb');
+        if ($moduleConfig === null) {
+            $moduleConfig = Config::module('icingadb');
         }
 
-        $section = $config->getSection('redis1');
+        if ($redisConfig === null) {
+            $redisConfig = Config::module('icingadb', 'redis');
+        }
+
+        $section = $redisConfig->getSection('redis1');
 
         $redis = new Redis([
             'host'      => $section->get('host', 'localhost'),
             'port'      => $section->get('port', 6380),
             'timeout'   => 0.5
-        ] + $this->getTlsParams($config));
+        ] + $this->getTlsParams($moduleConfig));
 
         $redis->ping();
 
         return $redis;
     }
 
-    public function getSecondaryRedis(Config $config = null)
+    public function getSecondaryRedis(Config $moduleConfig = null, Config $redisConfig = null)
     {
-        if ($config === null) {
-            $config = Config::module('icingadb');
+        if ($moduleConfig === null) {
+            $moduleConfig = Config::module('redis');
         }
 
-        $section = $config->getSection('redis2');
+        if ($redisConfig === null) {
+            $redisConfig = Config::module('icingadb', 'redis');
+        }
+
+        $section = $redisConfig->getSection('redis2');
         $host = $section->host;
 
         if (empty($host)) {
@@ -126,7 +134,7 @@ trait IcingaRedis
             'host'      => $host,
             'port'      => $section->get('port', 6380),
             'timeout'   => 0.5
-        ] + $this->getTlsParams($config));
+        ] + $this->getTlsParams($moduleConfig));
 
         $redis->ping();
 

--- a/library/Icingadb/Setup/RedisStep.php
+++ b/library/Icingadb/Setup/RedisStep.php
@@ -35,15 +35,16 @@ class RedisStep extends Step
         $moduleConfig = [
             'redis'  => [
                 'tls' => 0
-            ],
+            ]
+        ];
+        $redisConfig = [
             'redis1' => [
                 'host'  => $this->data['redis1_host'],
                 'port'  => $this->data['redis1_port'] ?: null
             ]
         ];
-
         if (isset($this->data['redis2_host']) && $this->data['redis2_host']) {
-            $moduleConfig['redis2'] = [
+            $redisConfig['redis2'] = [
                 'host'  => $this->data['redis2_host'],
                 'port'  => $this->data['redis2_port'] ?: null
             ];
@@ -80,6 +81,13 @@ class RedisStep extends Step
         try {
             $config = Config::module('icingadb', 'config', true);
             foreach ($moduleConfig as $section => $options) {
+                $config->setSection($section, $options);
+            }
+
+            $config->saveIni();
+
+            $config = Config::module('icingadb', 'redis', true);
+            foreach ($redisConfig as $section => $options) {
                 $config->setSection($section, $options);
             }
 


### PR DESCRIPTION
Commandtransports are very similar and are already stored in a separate file. This makes it so that the primary and secondary redis configs are stored in `redis.ini` rather than `config.ini`. TLS config is still stored in `config.ini`.