### PR TITLE
Fix failed localdateTime validation in Safari

### DIFF
--- a/application/forms/Command/Object/AcknowledgeProblemForm.php
+++ b/application/forms/Command/Object/AcknowledgeProblemForm.php
@@ -147,6 +147,7 @@ class AcknowledgeProblemForm extends CommandForm
                 [
                     'data-use-datetime-picker'  => true,
                     'required'                  => true,
+                    'step'                      => 1,
                     'value'                     => $expireTime,
                     'label'                     => t('Expire Time'),
                     'description'               => t(

--- a/application/forms/Command/Object/AddCommentForm.php
+++ b/application/forms/Command/Object/AddCommentForm.php
@@ -103,6 +103,7 @@ class AddCommentForm extends CommandForm
                 [
                     'data-use-datetime-picker'  => true,
                     'required'                  => true,
+                    'step'                      => 1,
                     'value'                     => $expireTime,
                     'label'                     => t('Expire Time'),
                     'description'               => t('Choose the date and time when Icinga should delete the comment.')

--- a/application/forms/Command/Object/ScheduleCheckForm.php
+++ b/application/forms/Command/Object/ScheduleCheckForm.php
@@ -70,6 +70,7 @@ class ScheduleCheckForm extends CommandForm
             [
                 'data-use-datetime-picker'  => true,
                 'required'                  => true,
+                'step'                      => 1,
                 'label'                     => t('Check Time'),
                 'description'               => t('Set the date and time when the check should be scheduled.'),
                 'value'                     => (new DateTime())->add(new DateInterval('PT1H'))

--- a/application/forms/Command/Object/ScheduleServiceDowntimeForm.php
+++ b/application/forms/Command/Object/ScheduleServiceDowntimeForm.php
@@ -117,6 +117,7 @@ class ScheduleServiceDowntimeForm extends CommandForm
             [
                 'data-use-datetime-picker'  => true,
                 'required'                  => true,
+                'step'                      => 1,
                 'value'                     => $this->start,
                 'label'                     => t('Start Time'),
                 'description'               => t('Set the start date and time for the downtime.')
@@ -130,6 +131,7 @@ class ScheduleServiceDowntimeForm extends CommandForm
             [
                 'data-use-datetime-picker'  => true,
                 'required'                  => true,
+                'step'                      => 1,
                 'label'                     => t('End Time'),
                 'description'               => t('Set the end date and time for the downtime.'),
                 'value'                     => $isFlexible ? $this->flexibleEnd : $this->fixedEnd,


### PR DESCRIPTION
This fixes the problem of failed localdateTime validation in Safari.

fix #255 