### PR TITLE
css: Remove z-index from footer

### DIFF
--- a/public/css/common.less
+++ b/public/css/common.less
@@ -239,8 +239,7 @@ div.show-more {
 
 .footer {
   display: flex;
-  box-shadow: 0 -1px 0 0px @gray-lighter;
-  z-index: 1000;
+  box-shadow: 0 -1px 0 0 @gray-lighter;
 
   .selection-count {
     flex: 1 1 auto;


### PR DESCRIPTION
The searchbar suggestions are overlapped by the footer. To fix this either the controls need a higher z-index or the footer gets his removed.

I opted for removing the footer's z-index. I cannot see a reason why it's necessary. It's never positioned and so doesn't need to be elevated.

I tested it on Chrome and Firefox. The box shadow is visible there, that's the only reason I thought why a z-index might be needed.