### PR TITLE
Fix/downtime progress bar height 263 fs

### DIFF
--- a/public/css/mixin/progress-bar.less
+++ b/public/css/mixin/progress-bar.less
@@ -104,20 +104,23 @@
     }
 
     .vertical-key-value {
+      max-width: 100%;
+
+      .key,
+      .value time {
+        .text-ellipsis();
+        max-width: 100%;
+        display: inline-block;
+      }
+
       .key {
         color: @gray;
       }
 
       .value {
-        white-space: nowrap;
         font-size: 1em;
         line-height: 1;
       }
-    }
-
-    .start .vertical-key-value,
-    .end .vertical-key-value {
-      width: 6em;
     }
 
     .timeline {


### PR DESCRIPTION
I branched your Fix/downtime-progress-bar-height-branch-263 and ellipsisized the overflowing labels as it looks more clean. Otherwise it would look like an error.

Of course I regarded that this crops the information displayed in some cases. But we can't control the length of strings anyway, especially when being translated.

To show the full strings one can hover the bubbles to see the `title` attribute contents.

What do you think, @nilmerg?