### PR TITLE
Add default path to icon img if no relative path has been specified

### DIFF
--- a/library/Icingadb/Widget/ItemList/StateListItem.php
+++ b/library/Icingadb/Widget/ItemList/StateListItem.php
@@ -60,6 +60,11 @@ abstract class StateListItem extends BaseListItem
     {
         if (isset($this->item->icon_image->icon_image)) {
             $src = $this->item->icon_image->icon_image;
+
+            if (strpos($src, '/') === false) {
+                $src = 'img/icons/' . $src;
+            }
+
             if (getenv('ICINGAWEB_EXPORT_FORMAT') === 'pdf') {
                 $srcUrl = Url::fromPath($src);
                 $path = $srcUrl->getRelativeUrl();


### PR DESCRIPTION
fix #388 