### PR TITLE
CSS: Align state-change soft-state-balls

### DIFF
--- a/public/css/widget/state-change.less
+++ b/public/css/widget/state-change.less
@@ -26,8 +26,9 @@
 
   .ball-size-l ~ .ball-size-ml {
     &.ball-size-ml {
-      margin-top: .26em;
+      margin-top: .25em;
       margin-left: -.375em;
+      margin-right: .25em;
     }
   }
 


### PR DESCRIPTION
This fixes the horizontal alignment of the smaller soft state state balls.