### PR TITLE
Add Overview, Problems and History menu when monitoring module is disabled

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -6,6 +6,8 @@ namespace Icinga\Module\Icingadb
 {
     use Exception;
     use Icinga\Authentication\Auth;
+    use Icinga\Module\Icingadb\Web\Navigation\Renderer\HostProblemsBadge;
+    use Icinga\Module\Icingadb\Web\Navigation\Renderer\ServiceProblemsBadge;
     use Icinga\Util\StringHelper;
     use ipl\Web\Widget\Icon;
     use RecursiveDirectoryIterator;
@@ -259,6 +261,159 @@ namespace Icinga\Module\Icingadb
             . '&view=minimal&limit=15&sort=host.state.severity desc',
             150
         );
+
+        /**
+         * @var \Icinga\Application\Modules\Module $this
+         *
+         * Problems section in case monitoring is disabled
+         */
+        $problemSection = $this->menuSection(N_('Problems'), [
+            'renderer' => array(
+                'TotalProblemsBadge',
+                'state' => 'critical'
+            ),
+            'icon'     => 'attention-circled',
+            'priority' => 20
+        ]);
+        $problemSection->add(N_('Host Problems'), [
+            'renderer' => (new HostProblemsBadge())->disableLink(),
+            'icon'        => 'server',
+            'description' => $this->translate('List current host problems'),
+            'url'       => 'icingadb/hosts?host.state.is_problem=y'
+                . '&sort=host.state.severity desc',
+            'priority'  => 50
+        ]);
+        $problemSection->add(N_('Service Problems'), [
+            'renderer' => (new ServiceProblemsBadge())->disableLink(),
+            'icon'        => 'cog',
+            'description' => $this->translate('List current service problems'),
+            'url'       => 'icingadb/services?service.state.is_problem=y'
+                . '&sort=service.state.severity desc',
+            'priority'  => 60
+        ]);
+        $problemSection->add(N_('Service Grid'), [
+            'icon'        => 'cogs',
+            'description' => $this->translate('Display service problems as grid'),
+            'url'         => 'icingadb/services/grid?problems',
+            'priority'    => 70
+        ]);
+
+        $problemSection->add(N_('Current Downtimes'), [
+            'description' => $this->translate('List current downtimes'),
+            'url' => 'icingadb/downtimes?downtime.is_in_effect=y',
+            'priority' => 80,
+            'icon'     => 'plug'
+        ]);
+
+        /**
+         * @var \Icinga\Application\Modules\Module $this
+         *
+         * Overview section in case monitoring is disabled
+         */
+        $overviewSection = $this->menuSection('Overview', [
+            'icon'      => 'binoculars',
+            'priority'  => 30
+        ]);
+
+        $overviewSection->add(N_('Tactical Overview'), [
+            'url' => 'icingadb/tactical',
+            'description' => $this->translate('Open tactical overview'),
+            'priority' => 40,
+            'icon'     => 'chart-pie'
+        ]);
+        $overviewSection->add(N_('Hosts'), [
+            'priority' => 50,
+            'description' => $this->translate('List hosts'),
+            'url'      => 'icingadb/hosts',
+            'icon'     => 'server'
+        ]);
+        $overviewSection->add(N_('Services'), [
+            'priority' => 50,
+            'description' => $this->translate('List services'),
+            'url'      => 'icingadb/services',
+            'icon'     => 'cog'
+        ]);
+        $auth = Auth::getInstance();
+        $routeBlacklist = [];
+        if ($auth->isAuthenticated() && ! $auth->getUser()->isUnrestricted()) {
+            // The empty array is for PHP pre 7.4, older versions require at least a single param for array_merge
+            $routeBlacklist = array_flip(array_merge([], ...array_map(function ($restriction) {
+                return StringHelper::trimSplit($restriction);
+            }, $auth->getRestrictions('icingadb/blacklist/routes'))));
+        }
+
+        if (! array_key_exists('servicegroups', $routeBlacklist)) {
+            $overviewSection->add(N_('Service Groups'), [
+                'description' => $this->translate('List service groups'),
+                'url' => 'icingadb/servicegroups',
+                'priority' => 60,
+                'icon'     => 'cogs'
+            ]);
+        }
+
+        if (! array_key_exists('hostgroups', $routeBlacklist)) {
+            $overviewSection->add(N_('Host Groups'), [
+                'description' => $this->translate('List host groups'),
+                'url' => 'icingadb/hostgroups',
+                'priority' => 60,
+                'icon'     => 'network-wired'
+            ]);
+        }
+
+        if (! array_key_exists('users', $routeBlacklist)) {
+            $overviewSection->add(N_('Contacts'), [
+                'description' => $this->translate('List contacts'),
+                'url' => 'icingadb/users',
+                'priority' => 70,
+                'icon'     => 'user-friends'
+            ]);
+        }
+
+        if (! array_key_exists('usergroups', $routeBlacklist)) {
+            $overviewSection->add(N_('Contactgroups'), [
+                'description' => $this->translate('List users'),
+                'url' => 'icingadb/usergroups',
+                'priority' => 70,
+                'icon'     => 'users'
+            ]);
+        }
+
+        $overviewSection->add(N_('Comments'), [
+            'url' => 'icingadb/comments',
+            'description' => $this->translate('List comments'),
+            'priority' => 80,
+            'icon'     => 'comments'
+        ]);
+        $overviewSection->add(N_('Downtimes'), [
+            'url' => 'icingadb/downtimes',
+            'description' => $this->translate('List downtimes'),
+            'priority' => 80,
+            'icon'     => 'plug'
+        ]);
+
+        /**
+         * @var \Icinga\Application\Modules\Module $this
+         *
+         * History section in case monitoring is disabled
+         */
+
+        $section = $this->menuSection(N_('History'), array(
+            'icon'      => 'history',
+            'priority'  => 90
+        ));
+
+        $section->add(N_('Event Overview'), array(
+            'icon'        => 'history',
+            'description' => $this->translate('Open event overview'),
+            'priority'    => 20,
+            'url'         => 'icingadb/history'
+        ));
+        $section->add(N_('Notifications'), array(
+            'icon'        => 'bell',
+            'description' => $this->translate('List notifications'),
+            'priority'    => 30,
+            'url'         => 'icingadb/notifications',
+        ));
     } else {
         /*
         * Available navigation items
@@ -271,104 +426,104 @@ namespace Icinga\Module\Icingadb
             'icingadb-service-action',
             $this->translate('Service Action') . ' (Icinga DB)'
         );
-    }
 
-    /** @var \Icinga\Application\Modules\Module $this */
-    $section = $this->menuSection('Icinga DB', [
-        'icon'     => 'database',
-        'priority' => 30
-    ]);
+        /** @var \Icinga\Application\Modules\Module $this */
+        $section = $this->menuSection('Icinga DB', [
+            'icon'     => 'database',
+            'priority' => 30
+        ]);
 
-    $section->add(N_('Hosts'), [
-        'priority' => 10,
-        'renderer' => 'HostProblemsBadge',
-        'url'      => 'icingadb/hosts',
-        'icon'     => 'server'
-    ]);
-    $section->add(N_('Services'), [
-        'priority' => 20,
-        'renderer' => 'ServiceProblemsBadge',
-        'url'      => 'icingadb/services',
-        'icon'     => 'cog'
-    ]);
-    $section->add(N_('Downtimes'), [
-        'url' => 'icingadb/downtimes',
-        'priority' => 30,
-        'icon'     => 'plug'
-    ]);
-    $section->add(N_('Comments'), [
-        'url' => 'icingadb/comments',
-        'priority' => 40,
-        'icon'     => 'comments'
-    ]);
-    $section->add(N_('Notifications'), [
-        'url' => 'icingadb/notifications',
-        'priority' => 50,
-        'icon'     => 'bell'
-    ]);
-    $section->add(N_('Service Grid'), [
-        'icon'        => 'cog',
-        'description' => $this->translate('Display service problems as grid'),
-        'url'         => 'icingadb/services/grid?problems',
-        'priority'    => 70
-    ]);
+        $section->add(N_('Hosts'), [
+            'priority' => 10,
+            'renderer' => 'HostProblemsBadge',
+            'url'      => 'icingadb/hosts',
+            'icon'     => 'server'
+        ]);
+        $section->add(N_('Services'), [
+            'priority' => 20,
+            'renderer' => 'ServiceProblemsBadge',
+            'url'      => 'icingadb/services',
+            'icon'     => 'cog'
+        ]);
+        $section->add(N_('Downtimes'), [
+            'url' => 'icingadb/downtimes',
+            'priority' => 30,
+            'icon'     => 'plug'
+        ]);
+        $section->add(N_('Comments'), [
+            'url' => 'icingadb/comments',
+            'priority' => 40,
+            'icon'     => 'comments'
+        ]);
+        $section->add(N_('Notifications'), [
+            'url' => 'icingadb/notifications',
+            'priority' => 50,
+            'icon'     => 'bell'
+        ]);
+        $section->add(N_('Service Grid'), [
+            'icon'        => 'cog',
+            'description' => $this->translate('Display service problems as grid'),
+            'url'         => 'icingadb/services/grid?problems',
+            'priority'    => 70
+        ]);
 
-    $auth = Auth::getInstance();
-    $routeBlacklist = [];
-    if ($auth->isAuthenticated() && ! $auth->getUser()->isUnrestricted()) {
-        // The empty array is for PHP pre 7.4, older versions require at least a single param for array_merge
-        $routeBlacklist = array_flip(array_merge([], ...array_map(function ($restriction) {
-            return StringHelper::trimSplit($restriction);
-        }, $auth->getRestrictions('icingadb/blacklist/routes'))));
-    }
+        $auth = Auth::getInstance();
+        $routeBlacklist = [];
+        if ($auth->isAuthenticated() && ! $auth->getUser()->isUnrestricted()) {
+            // The empty array is for PHP pre 7.4, older versions require at least a single param for array_merge
+            $routeBlacklist = array_flip(array_merge([], ...array_map(function ($restriction) {
+                return StringHelper::trimSplit($restriction);
+            }, $auth->getRestrictions('icingadb/blacklist/routes'))));
+        }
 
-    if (! array_key_exists('users', $routeBlacklist)) {
-        $section->add(N_('Users'), [
-            'url' => 'icingadb/users',
-            'priority' => 60,
-            'icon'     => 'user-friends'
+        if (! array_key_exists('users', $routeBlacklist)) {
+            $section->add(N_('Users'), [
+                'url' => 'icingadb/users',
+                'priority' => 60,
+                'icon'     => 'user-friends'
+            ]);
+        }
+
+        if (! array_key_exists('usergroups', $routeBlacklist)) {
+            $section->add(N_('User Groups'), [
+                'url' => 'icingadb/usergroups',
+                'priority' => 70,
+                'icon'     => 'users'
+            ]);
+        }
+
+        if (! array_key_exists('hostgroups', $routeBlacklist)) {
+            $section->add(N_('Host Groups'), [
+                'url' => 'icingadb/hostgroups',
+                'priority' => 80,
+                'icon'     => 'network-wired'
+            ]);
+        }
+
+        if (! array_key_exists('servicegroups', $routeBlacklist)) {
+            $section->add(N_('Service Groups'), [
+                'url' => 'icingadb/servicegroups',
+                'priority' => 80,
+                'icon'     => 'cogs'
+            ]);
+        }
+
+        $section->add(N_('History'), [
+            'url' => 'icingadb/history',
+            'priority' => 90,
+            'icon'     => 'history'
+        ]);
+        $section->add(N_('Health'), [
+            'url' => 'icingadb/health',
+            'priority' => 100,
+            'icon'     => 'heartbeat'
+        ]);
+        $section->add(N_('Tactical Overview'), [
+            'url' => 'icingadb/tactical',
+            'priority' => 110,
+            'icon'     => 'chart-pie'
         ]);
     }
-
-    if (! array_key_exists('usergroups', $routeBlacklist)) {
-        $section->add(N_('User Groups'), [
-            'url' => 'icingadb/usergroups',
-            'priority' => 70,
-            'icon'     => 'users'
-        ]);
-    }
-
-    if (! array_key_exists('hostgroups', $routeBlacklist)) {
-        $section->add(N_('Host Groups'), [
-            'url' => 'icingadb/hostgroups',
-            'priority' => 80,
-            'icon'     => 'network-wired'
-        ]);
-    }
-
-    if (! array_key_exists('servicegroups', $routeBlacklist)) {
-        $section->add(N_('Service Groups'), [
-            'url' => 'icingadb/servicegroups',
-            'priority' => 80,
-            'icon'     => 'cogs'
-        ]);
-    }
-
-    $section->add(N_('History'), [
-        'url' => 'icingadb/history',
-        'priority' => 90,
-        'icon'     => 'history'
-    ]);
-    $section->add(N_('Health'), [
-        'url' => 'icingadb/health',
-        'priority' => 100,
-        'icon'     => 'heartbeat'
-    ]);
-    $section->add(N_('Tactical Overview'), [
-        'url' => 'icingadb/tactical',
-        'priority' => 110,
-        'icon'     => 'chart-pie'
-    ]);
 
     $this->provideConfigTab('database', [
         'label' => t('Database'),

--- a/library/Icingadb/Web/Navigation/Renderer/ProblemsBadge.php
+++ b/library/Icingadb/Web/Navigation/Renderer/ProblemsBadge.php
@@ -30,11 +30,13 @@ abstract class ProblemsBadge extends NavigationItemRenderer
     /** @var string Title */
     protected $title;
 
+    protected $linkDisabled;
+
     abstract protected function fetchProblemsCount();
 
     abstract protected function getUrl();
 
-    protected function getProblemsCount()
+    public function getProblemsCount()
     {
         if ($this->count === null) {
             try {
@@ -114,9 +116,28 @@ abstract class ProblemsBadge extends NavigationItemRenderer
 
         $item->setCssClass('badge-nav-item icinga-module module-icingadb');
 
+        $badge = $this->createBadge();
+
+        if ($this->linkDisabled) {
+            $badge->addAttributes(['class' => 'disabled']);
+            $this->setEscapeLabel(false);
+            $label = $this->view()->escape($item->getLabel());
+            $item->setLabel($badge . $label);
+
+            return (new HtmlDocument())
+                ->add(new HtmlString(parent::render($item)))
+                ->render();
+        }
+
+        $badge = new Link(
+            $badge,
+            $this->getUrl(),
+            ['title' => $this->getTitle()]
+        );
+
         return (new HtmlDocument())
             ->add(new HtmlString(parent::render($item)))
-            ->add($this->createBadge())
+            ->add($badge)
             ->render();
     }
 
@@ -125,12 +146,8 @@ abstract class ProblemsBadge extends NavigationItemRenderer
         $count = $this->getProblemsCount();
 
         if ($count) {
-            return new Link(
-                (new StateBadge($count, $this->getState()))
-                    ->addAttributes(['class' => 'badge']),
-                $this->getUrl(),
-                ['title' => $this->getTitle()]
-            );
+            return (new StateBadge($count, $this->getState()))
+                    ->addAttributes(['class' => 'badge']);
         }
 
         return null;
@@ -145,5 +162,12 @@ abstract class ProblemsBadge extends NavigationItemRenderer
         }
 
         return $count;
+    }
+
+    public function disableLink()
+    {
+        $this->linkDisabled = true;
+
+        return $this;
     }
 }

--- a/library/Icingadb/Web/Navigation/Renderer/TotalProblemsBadge.php
+++ b/library/Icingadb/Web/Navigation/Renderer/TotalProblemsBadge.php
@@ -1,0 +1,66 @@
+<?php
+
+/* Icinga DB Web | (c) 2021 Icinga GmbH | GPLv2 */
+
+namespace Icinga\Module\Icingadb\Web\Navigation\Renderer;
+
+use Icinga\Web\Navigation\Renderer\BadgeNavigationItemRenderer;
+
+class TotalProblemsBadge extends BadgeNavigationItemRenderer
+{
+    /**
+     * Cached count
+     *
+     * @var int
+     */
+    protected $count;
+
+    /**
+     * State to severity map
+     *
+     * @var array
+     */
+    protected static $stateSeverityMap = [
+        self::STATE_OK          => 0,
+        self::STATE_PENDING     => 1,
+        self::STATE_UNKNOWN     => 2,
+        self::STATE_WARNING     => 3,
+        self::STATE_CRITICAL    => 4,
+    ];
+
+    /**
+     * Severity to state map
+     *
+     * @var array
+     */
+    protected static $severityStateMap = [
+        self::STATE_OK,
+        self::STATE_PENDING,
+        self::STATE_UNKNOWN,
+        self::STATE_WARNING,
+        self::STATE_CRITICAL
+    ];
+
+    public function getCount()
+    {
+        if ($this->count === null) {
+            $countMap = array_fill(0, 5, 0);
+            $maxSeverity = 0;
+            foreach ($this->getItem()->getChildren() as $child) {
+                $renderer = $child->getRenderer();
+                if ($renderer instanceof ProblemsBadge) {
+                    $count = $renderer->getProblemsCount();
+                    if ($count) {
+                        $severity = static::$stateSeverityMap[$renderer->getState()];
+                        $countMap[$severity] += $count;
+                        $maxSeverity = max($maxSeverity, $severity);
+                    }
+                }
+            }
+            $this->count = $countMap[$maxSeverity];
+            $this->state = static::$severityStateMap[$maxSeverity];
+        }
+
+        return $this->count;
+    }
+}

--- a/public/css/widget/state-badge.less
+++ b/public/css/widget/state-badge.less
@@ -53,7 +53,7 @@
 }
 
 a .state-badge {
-  &:hover {
+  &:not(.disabled):hover {
     filter: brightness(80%);
   }
 }


### PR DESCRIPTION

When monitoring module is disabled instead of showing host and service details in Icinga DB menu, the details needs to be distributed in Overview, Problems and History menus respectively.
This is to imitate the case when only monitoring module is active.

fix #394 