### PR TITLE
Macros: Fix return type mismatch

### DIFF
--- a/library/Icingadb/Common/Macros.php
+++ b/library/Icingadb/Common/Macros.php
@@ -98,19 +98,19 @@ trait Macros
                 } while (! empty($properties) && $value !== null);
             } else {
                 $value = $object->$macro;
-
-                if ($value instanceof Query || $value instanceof ResultSet || is_array($value)) {
-                    Logger::debug(
-                        'It is not allowed to use "%s" as a macro which produces a "%s" type as a result.',
-                        $macro,
-                        get_php_type($value)
-                    );
-                    $value = null;
-                }
             }
         } catch (\Exception $e) {
             $value = null;
             Logger::debug('Unable to resolve macro "%s". An error occurred: %s', $macro, $e);
+        }
+
+        if ($value instanceof Query || $value instanceof ResultSet || is_array($value)) {
+            Logger::debug(
+                'It is not allowed to use "%s" as a macro which produces a "%s" type as a result.',
+                $macro,
+                get_php_type($value)
+            );
+            $value = null;
         }
 
         return $value !== null ? $value : $macro;


### PR DESCRIPTION
Let's say we have `$host.hostgroup$` as a macro. In the do while loop our first and last column/property is `hostgroup`. But we check at the beginning only if `$value` isn't of these types `Query, ResultSet, Array` and then defeeferencing `$value->hostgroup` after which `$properties` is going to be empty and the type checks will never be executed for the second time.