### PR TITLE
Implement schema command_id prefix change

### DIFF
--- a/library/Icingadb/Model/Checkcommand.php
+++ b/library/Icingadb/Model/Checkcommand.php
@@ -69,10 +69,8 @@ class Checkcommand extends Model
         $relations->belongsToMany('vars', CustomvarFlat::class)
             ->through(CheckcommandCustomvar::class);
 
-        $relations->hasMany('argument', CheckcommandArgument::class)
-            ->setForeignKey('command_id');
-        $relations->hasMany('envvar', CheckcommandEnvvar::class)
-            ->setForeignKey('command_id');
+        $relations->hasMany('argument', CheckcommandArgument::class);
+        $relations->hasMany('envvar', CheckcommandEnvvar::class);
         $relations->hasMany('host', Host::class);
         $relations->hasMany('service', Service::class);
     }

--- a/library/Icingadb/Model/CheckcommandArgument.php
+++ b/library/Icingadb/Model/CheckcommandArgument.php
@@ -22,7 +22,7 @@ class CheckcommandArgument extends Model
     public function getColumns()
     {
         return [
-            'command_id',
+            'checkcommand_id',
             'argument_key',
             'environment_id',
             'properties_checksum',
@@ -40,7 +40,7 @@ class CheckcommandArgument extends Model
     public function getMetaData()
     {
         return [
-            'command_id'            => t('Checkcommand Argument Command Id'),
+            'checkcommand_id'       => t('Checkcommand Argument Command Id'),
             'argument_key'          => t('Checkcommand Argument Key'),
             'environment_id'        => t('Checkcommand Argument Environment Id'),
             'properties_checksum'   => t('Checkcommand Argument Properties Checksum'),
@@ -58,7 +58,6 @@ class CheckcommandArgument extends Model
     public function createRelations(Relations $relations)
     {
         $relations->belongsTo('environment', Environment::class);
-        $relations->belongsTo('checkcommand', CheckCommand::class)
-            ->setCandidateKey('command_id');
+        $relations->belongsTo('checkcommand', CheckCommand::class);
     }
 }

--- a/library/Icingadb/Model/CheckcommandCustomvar.php
+++ b/library/Icingadb/Model/CheckcommandCustomvar.php
@@ -22,7 +22,7 @@ class CheckcommandCustomvar extends Model
     public function getColumns()
     {
         return [
-            'command_id',
+            'checkcommand_id',
             'customvar_id',
             'environment_id'
         ];
@@ -31,8 +31,7 @@ class CheckcommandCustomvar extends Model
     public function createRelations(Relations $relations)
     {
         $relations->belongsTo('environment', Environment::class);
-        $relations->belongsTo('checkcommand', CheckCommand::class)
-            ->setCandidateKey('command_id');
+        $relations->belongsTo('checkcommand', CheckCommand::class);
         $relations->belongsTo('customvar', Customvar::class);
         $relations->belongsTo('customvar_flat', CustomvarFlat::class)
             ->setCandidateKey('customvar_id')

--- a/library/Icingadb/Model/CheckcommandEnvvar.php
+++ b/library/Icingadb/Model/CheckcommandEnvvar.php
@@ -22,7 +22,7 @@ class CheckcommandEnvvar extends Model
     public function getColumns()
     {
         return [
-            'command_id',
+            'checkcommand_id',
             'envvar_key',
             'environment_id',
             'properties_checksum',
@@ -33,7 +33,7 @@ class CheckcommandEnvvar extends Model
     public function getMetaData()
     {
         return [
-            'command_id'            => t('Checkcommand Envvar Command Id'),
+            'checkcommand_id'       => t('Checkcommand Envvar Command Id'),
             'envvar_key'            => t('Checkcommand Envvar Key'),
             'environment_id'        => t('Checkcommand Environment Id'),
             'properties_checksum'   => t('Checkcommand Properties Checksum'),
@@ -44,7 +44,6 @@ class CheckcommandEnvvar extends Model
     public function createRelations(Relations $relations)
     {
         $relations->belongsTo('environment', Environment::class);
-        $relations->belongsTo('checkcommand', CheckCommand::class)
-            ->setCandidateKey('command_id');
+        $relations->belongsTo('checkcommand', CheckCommand::class);
     }
 }

--- a/library/Icingadb/Model/Eventcommand.php
+++ b/library/Icingadb/Model/Eventcommand.php
@@ -69,10 +69,8 @@ class Eventcommand extends Model
         $relations->belongsToMany('vars', CustomvarFlat::class)
             ->through(EventcommandCustomvar::class);
 
-        $relations->hasMany('argument', EventcommandArgument::class)
-            ->setForeignKey('command_id');
-        $relations->hasMany('envvar', EventcommandEnvvar::class)
-            ->setForeignKey('command_id');
+        $relations->hasMany('argument', EventcommandArgument::class);
+        $relations->hasMany('envvar', EventcommandEnvvar::class);
         $relations->hasMany('host', Host::class);
         $relations->hasMany('service', Service::class);
     }

--- a/library/Icingadb/Model/EventcommandArgument.php
+++ b/library/Icingadb/Model/EventcommandArgument.php
@@ -22,7 +22,7 @@ class EventcommandArgument extends Model
     public function getColumns()
     {
         return [
-            'command_id',
+            'eventcommand_id',
             'argument_key',
             'environment_id',
             'properties_checksum',
@@ -40,7 +40,7 @@ class EventcommandArgument extends Model
     public function getMetaData()
     {
         return [
-            'command_id'            => t('Eventcommand Argument Command Id'),
+            'eventcommand_id'       => t('Eventcommand Argument Command Id'),
             'argument_key'          => t('Eventcommand Argument Key'),
             'environment_id'        => t('Eventcommand Argument Environment Id'),
             'properties_checksum'   => t('Eventcommand Argument Properties Checksum'),
@@ -58,7 +58,6 @@ class EventcommandArgument extends Model
     public function createRelations(Relations $relations)
     {
         $relations->belongsTo('environment', Environment::class);
-        $relations->belongsTo('eventcommand', Eventcommand::class)
-            ->setCandidateKey('command_id');
+        $relations->belongsTo('eventcommand', Eventcommand::class);
     }
 }

--- a/library/Icingadb/Model/EventcommandCustomvar.php
+++ b/library/Icingadb/Model/EventcommandCustomvar.php
@@ -22,7 +22,7 @@ class EventcommandCustomvar extends Model
     public function getColumns()
     {
         return [
-            'command_id',
+            'eventcommand_id',
             'customvar_id',
             'environment_id'
         ];
@@ -31,8 +31,7 @@ class EventcommandCustomvar extends Model
     public function createRelations(Relations $relations)
     {
         $relations->belongsTo('environment', Environment::class);
-        $relations->belongsTo('eventcommand', Eventcommand::class)
-            ->setCandidateKey('command_id');
+        $relations->belongsTo('eventcommand', Eventcommand::class);
         $relations->belongsTo('customvar', Customvar::class);
         $relations->belongsTo('customvar_flat', CustomvarFlat::class)
             ->setCandidateKey('customvar_id')

--- a/library/Icingadb/Model/EventcommandEnvvar.php
+++ b/library/Icingadb/Model/EventcommandEnvvar.php
@@ -22,7 +22,7 @@ class EventcommandEnvvar extends Model
     public function getColumns()
     {
         return [
-            'command_id',
+            'eventcommand_id',
             'envvar_key',
             'environment_id',
             'properties_checksum',
@@ -33,7 +33,7 @@ class EventcommandEnvvar extends Model
     public function getMetaData()
     {
         return [
-            'command_id'            => t('Eventcommand Envvar Command Id'),
+            'eventcommand_id'       => t('Eventcommand Envvar Command Id'),
             'envvar_key'            => t('Eventcommand Envvar Key'),
             'environment_id'        => t('Eventcommand Envvar Environment Id'),
             'properties_checksum'   => t('Eventcommand Envvar Properties Checksum'),
@@ -44,7 +44,6 @@ class EventcommandEnvvar extends Model
     public function createRelations(Relations $relations)
     {
         $relations->belongsTo('environment', Environment::class);
-        $relations->belongsTo('eventcommand', Eventcommand::class)
-            ->setCandidateKey('command_id');
+        $relations->belongsTo('eventcommand', Eventcommand::class);
     }
 }

--- a/library/Icingadb/Model/Notification.php
+++ b/library/Icingadb/Model/Notification.php
@@ -32,7 +32,7 @@ class Notification extends Model
             'name_ci',
             'host_id',
             'service_id',
-            'command_id',
+            'notificationcommand_id',
             'times_begin',
             'times_end',
             'notification_interval',
@@ -46,21 +46,21 @@ class Notification extends Model
     public function getMetaData()
     {
         return [
-            'environment_id'        => t('Notification Environment Id'),
-            'name_checksum'         => t('Notification Name Checksum'),
-            'properties_checksum'   => t('Notification Properties Checksum'),
-            'name'                  => t('Notification Name'),
-            'name_ci'               => t('Notification Name (CI)'),
-            'host_id'               => t('Notification Host Id'),
-            'service_id'            => t('Notification Service Id'),
-            'command_id'            => t('Notification Command Id'),
-            'times_begin'           => t('Notification Times Begin'),
-            'times_end'             => t('Notification Times End'),
-            'notification_interval' => t('Notification Interval'),
-            'timeperiod_id'         => t('Notification Timeperiod Id'),
-            'states'                => t('Notification States'),
-            'types'                 => t('Notification Types'),
-            'zone_id'               => t('Notification Zone Id')
+            'environment_id'         => t('Notification Environment Id'),
+            'name_checksum'          => t('Notification Name Checksum'),
+            'properties_checksum'    => t('Notification Properties Checksum'),
+            'name'                   => t('Notification Name'),
+            'name_ci'                => t('Notification Name (CI)'),
+            'host_id'                => t('Notification Host Id'),
+            'service_id'             => t('Notification Service Id'),
+            'notificationcommand_id' => t('Notification Command Id'),
+            'times_begin'            => t('Notification Times Begin'),
+            'times_end'              => t('Notification Times End'),
+            'notification_interval'  => t('Notification Interval'),
+            'timeperiod_id'          => t('Notification Timeperiod Id'),
+            'states'                 => t('Notification States'),
+            'types'                  => t('Notification Types'),
+            'zone_id'                => t('Notification Zone Id')
         ];
     }
 
@@ -98,8 +98,7 @@ class Notification extends Model
         $relations->belongsTo('environment', Environment::class);
         $relations->belongsTo('host', Host::class);
         $relations->belongsTo('service', Service::class);
-        $relations->belongsTo('notificationcommand', Notificationcommand::class)
-            ->setCandidateKey('command_id');
+        $relations->belongsTo('notificationcommand', Notificationcommand::class);
         $relations->belongsTo('timeperiod', Timeperiod::class);
         $relations->belongsTo('zone', Zone::class);
 

--- a/library/Icingadb/Model/Notificationcommand.php
+++ b/library/Icingadb/Model/Notificationcommand.php
@@ -71,11 +71,8 @@ class Notificationcommand extends Model
         $relations->belongsToMany('vars', CustomvarFlat::class)
             ->through(NotificationcommandCustomvar::class);
 
-        $relations->hasMany('notification', Notification::class)
-            ->setForeignKey('command_id');
-        $relations->hasMany('argument', NotificationcommandArgument::class)
-            ->setForeignKey('command_id');
-        $relations->hasMany('envvar', NotificationcommandEnvvar::class)
-            ->setForeignKey('command_id');
+        $relations->hasMany('notification', Notification::class);
+        $relations->hasMany('argument', NotificationcommandArgument::class);
+        $relations->hasMany('envvar', NotificationcommandEnvvar::class);
     }
 }

--- a/library/Icingadb/Model/NotificationcommandArgument.php
+++ b/library/Icingadb/Model/NotificationcommandArgument.php
@@ -22,7 +22,7 @@ class NotificationcommandArgument extends Model
     public function getColumns()
     {
         return [
-            'command_id',
+            'notificationcommand_id',
             'argument_key',
             'environment_id',
             'properties_checksum',
@@ -40,25 +40,24 @@ class NotificationcommandArgument extends Model
     public function getMetaData()
     {
         return [
-            'command_id'            => t('Notificationcommand Argument Command Id'),
-            'argument_key'          => t('Notificationcommand Argument Key'),
-            'environment_id'        => t('Notificationcommand Argument Environment Id'),
-            'properties_checksum'   => t('Notificationcommand Argument Properties Checksum'),
-            'argument_value'        => t('Notificationcommand Argument Value'),
-            'argument_order'        => t('Notificationcommand Argument Order'),
-            'description'           => t('Notificationcommand Argument Description'),
-            'argument_key_override' => t('Notificationcommand Argument Key Override'),
-            'repeat_key'            => t('Notificationcommand Argument Repeat Key'),
-            'required'              => t('Notificationcommand Argument Required'),
-            'set_if'                => t('Notificationcommand Argument Set If'),
-            'skip_key'              => t('Notificationcommand Argument Skip Key')
+            'notificationcommand_id' => t('Notificationcommand Argument Command Id'),
+            'argument_key'           => t('Notificationcommand Argument Key'),
+            'environment_id'         => t('Notificationcommand Argument Environment Id'),
+            'properties_checksum'    => t('Notificationcommand Argument Properties Checksum'),
+            'argument_value'         => t('Notificationcommand Argument Value'),
+            'argument_order'         => t('Notificationcommand Argument Order'),
+            'description'            => t('Notificationcommand Argument Description'),
+            'argument_key_override'  => t('Notificationcommand Argument Key Override'),
+            'repeat_key'             => t('Notificationcommand Argument Repeat Key'),
+            'required'               => t('Notificationcommand Argument Required'),
+            'set_if'                 => t('Notificationcommand Argument Set If'),
+            'skip_key'               => t('Notificationcommand Argument Skip Key')
         ];
     }
 
     public function createRelations(Relations $relations)
     {
         $relations->belongsTo('environment', Environment::class);
-        $relations->belongsTo('notificationcommand', Notificationcommand::class)
-            ->setCandidateKey('command_id');
+        $relations->belongsTo('notificationcommand', Notificationcommand::class);
     }
 }

--- a/library/Icingadb/Model/NotificationcommandCustomvar.php
+++ b/library/Icingadb/Model/NotificationcommandCustomvar.php
@@ -22,7 +22,7 @@ class NotificationcommandCustomvar extends Model
     public function getColumns()
     {
         return [
-            'command_id',
+            'notificationcommand_id',
             'customvar_id',
             'environment_id'
         ];
@@ -31,8 +31,7 @@ class NotificationcommandCustomvar extends Model
     public function createRelations(Relations $relations)
     {
         $relations->belongsTo('environment', Environment::class);
-        $relations->belongsTo('notificationcommand', Notificationcommand::class)
-            ->setCandidateKey('command_id');
+        $relations->belongsTo('notificationcommand', Notificationcommand::class);
         $relations->belongsTo('customvar', Customvar::class);
         $relations->belongsTo('customvar_flat', CustomvarFlat::class)
             ->setCandidateKey('customvar_id')

--- a/library/Icingadb/Model/NotificationcommandEnvvar.php
+++ b/library/Icingadb/Model/NotificationcommandEnvvar.php
@@ -22,7 +22,7 @@ class NotificationcommandEnvvar extends Model
     public function getColumns()
     {
         return [
-            'command_id',
+            'notificationcommand_id',
             'envvar_key',
             'environment_id',
             'properties_checksum',
@@ -33,18 +33,17 @@ class NotificationcommandEnvvar extends Model
     public function getMetaData()
     {
         return [
-            'command_id'            => t('Notificationcommand Envvar Command Id'),
-            'envvar_key'            => t('Notificationcommand Envvar Key'),
-            'environment_id'        => t('Notificationcommand Envvar Environment Id'),
-            'properties_checksum'   => t('Notificationcommand Envvar Properties Checksum'),
-            'envvar_value'          => t('Notificationcommand Envvar Value')
+            'notificationcommand_id' => t('Notificationcommand Envvar Command Id'),
+            'envvar_key'             => t('Notificationcommand Envvar Key'),
+            'environment_id'         => t('Notificationcommand Envvar Environment Id'),
+            'properties_checksum'    => t('Notificationcommand Envvar Properties Checksum'),
+            'envvar_value'           => t('Notificationcommand Envvar Value')
         ];
     }
 
     public function createRelations(Relations $relations)
     {
         $relations->belongsTo('environment', Environment::class);
-        $relations->belongsTo('notificationcommand', Notificationcommand::class)
-            ->setCandidateKey('command_id');
+        $relations->belongsTo('notificationcommand', Notificationcommand::class);
     }
 }


### PR DESCRIPTION
This PR implements schema changes to the command reference IDs (Added {check,notification,event} prefix to command_id columns)

Icinga DB PR: https://github.com/Icinga/icingadb/pull/385

Affected relations:
- {check,notitication,event}command: envvar, argument, customvar

## Tests:

I wasn't quite sure how to test those relations, but found that it's enough to get an empty result while using the search bar to show that the relation is working. Broken relations would result in a "Relation not found" error.

### Checkcommand:
- Argument: http://10.211.55.8/icingaweb2/icingadb/services?service.checkcommand.argument.description
- Envvar: http://10.211.55.8/icingaweb2/icingadb/services?service.checkcommand.envvar.envvar_key
- Customvar: http://10.211.55.8/icingaweb2/icingadb/services?service.checkcommand.customvar.name

### Eventcomand:
- Argument: http://10.211.55.8/icingaweb2/icingadb/services?service.eventcommand.argument.description
- Envvar: http://10.211.55.8/icingaweb2/icingadb/services?service.eventcommand.envvar.envvar_key
- Customvar: http://10.211.55.8/icingaweb2/icingadb/services?service.eventcommand.customvar.name

### Notificationcommand:
- Argument: http://10.211.55.8/icingaweb2/icingadb/services?service.notification.notificationcommand.argument.description
- Envvar: http://10.211.55.8/icingaweb2/icingadb/services?service.notification.notificationcommand.envvar.envvar_key
- Customvar: http://10.211.55.8/icingaweb2/icingadb/services?service.notification.notificationcommand.customvar.name
