### PR TITLE
Use the empty string for probing the Icinga 2 API

### DIFF
--- a/library/Icingadb/Command/Transport/ApiCommandTransport.php
+++ b/library/Icingadb/Command/Transport/ApiCommandTransport.php
@@ -312,7 +312,7 @@ class ApiCommandTransport implements CommandTransportInterface
     {
         try {
             $response = (new Client())
-                ->get($this->getUriFor(null), [
+                ->get($this->getUriFor(''), [
                     'auth'          => [$this->getUsername(), $this->getPassword()],
                     'headers'       => ['Accept' => 'application/json'],
                     'http_errors'   => false,


### PR DESCRIPTION
Using null results in an argument type error.