### PR TITLE
Fix Column 'host_id' in where clause is ambiguous

### DIFF
--- a/application/controllers/HostController.php
+++ b/application/controllers/HostController.php
@@ -63,7 +63,7 @@ class HostController extends Controller
     {
         $serviceSummary = ServicestateSummary::on($this->getDb())->with('state');
         $serviceSummary->getSelectBase()
-            ->where(['host_id = ?' => $this->host->id]);
+            ->where(['service.host_id = ?' => $this->host->id]);
 
         $this->applyRestrictions($serviceSummary);
 


### PR DESCRIPTION
service_state now also has the host_id column, so we need to
qualify host_id with a table name in the WHERE condition.

This is a preparation for Icinga/icingadb#403, and can already be merged.