### PR TITLE
IcingadbSupportHook: Rename method to `isIcingaDbSetAsPreferredBackend()`

### DIFF
--- a/library/Icingadb/Hook/IcingadbSupportHook.php
+++ b/library/Icingadb/Hook/IcingadbSupportHook.php
@@ -47,6 +47,7 @@ abstract class IcingadbSupportHook
      */
     final public static function useIcingaDbAsBackend(): bool
     {
-        return ! Icinga::app()->getModuleManager()->hasEnabled('monitoring') || self::isSetAsBackend();
+        return ! Icinga::app()->getModuleManager()->hasEnabled('monitoring')
+            || self::isIcingaDbSetAsPreferredBackend();
     }
 }


### PR DESCRIPTION
Rename method  `isSetAsBackend()` to `isIcingaDbSetAsPreferredBackend()`