### PR TITLE
ApiTransportForm: Don't use text to create password elements

### DIFF
--- a/application/forms/ApiTransportForm.php
+++ b/application/forms/ApiTransportForm.php
@@ -49,9 +49,9 @@ class ApiTransportForm extends CompatForm
             'description'   => t('User to authenticate with using HTTP Basic Auth')
         ]);
 
-        // TODO: Use a password element
-        $this->addElement('text', 'password', [
+        $this->addElement('password', 'password', [
             'required'      => true,
+            'autocomplete'  => 'new-password',
             'label'         => t('API Password')
         ]);
 


### PR DESCRIPTION
resolves #459 