### PR TITLE
Use a red background on focus for remove buttons

### DIFF
--- a/public/css/common.less
+++ b/public/css/common.less
@@ -251,7 +251,8 @@ div.show-more {
   .var(border-color, color-critical);
   .var(color, color-critical);
 
-  &:hover {
+  &:hover,
+  &:focus {
     .var(background-color, color-critical);
     .var(color, text-color-on-icinga-blue);
   }


### PR DESCRIPTION
Remove comment or downtime: When you click the "Remove" button, the background of the button changes to icinga-blue with a red border (looks strange).

![Screenshot 2022-01-26 at 09 58 45](https://user-images.githubusercontent.com/54990055/151141843-3cae85bb-4a3d-4b5b-96e0-ba576487a8fe.png)

fixes #483