### PR TITLE
view-mode-switcher: Optimize for theming

### DIFF
--- a/public/css/widget/view-mode-switcher.less
+++ b/public/css/widget/view-mode-switcher.less
@@ -9,7 +9,7 @@
   }
 
   label {
-    color: @icinga-blue;
+    color: @control-color;
     line-height: 1;
     background: @low-sat-blue;
     padding: 14/16*.25em 14/16*.5em;
@@ -38,7 +38,7 @@
   }
 
   input[checked] + label {
-    background-color: @icinga-blue;
+    background-color: @control-color;
     color: @text-color-on-icinga-blue;
     cursor: default;
   }


### PR DESCRIPTION
There were some issues with the `.view-mode-switcher` not being consistent with the rest of the controls.

This makes it more consistent, when overriding colors in themes.

related to [Icinga/icingaweb2/#4673](https://github.com/Icinga/icingaweb2/pull/4673)
and [Icinga/ipl-web/#67](https://github.com/Icinga/ipl-web/compare/bugfix/css-fix-theme-issues?expand=1)