### PR TITLE
Model\Instance: sort rows of equal responsibility by latest heartbeat

### DIFF
--- a/library/Icingadb/Model/Instance.php
+++ b/library/Icingadb/Model/Instance.php
@@ -42,7 +42,7 @@ class Instance extends Model
 
     public function getDefaultSort()
     {
-        return 'responsible desc';
+        return ['responsible desc', 'heartbeat desc'];
     }
 
     public function createBehaviors(Behaviors $behaviors)


### PR DESCRIPTION
In case of multiple responsible=y rows (crashed instance and running instance)
make sure to get the one with the latest heartbeat not to give a false positive "Icinga DB is not running" (other heartbeat expired).

refs Icinga/icingadb#424