### PR TITLE
DowntimeDetail: Don't register class `subject` twice

### DIFF
--- a/library/Icingadb/Widget/Detail/DowntimeDetail.php
+++ b/library/Icingadb/Widget/Detail/DowntimeDetail.php
@@ -124,7 +124,6 @@ class DowntimeDetail extends BaseHtmlElement
                     ($relatedDowntime->object_type === 'host'
                         ? $this->createHostLink($relatedDowntime->host, true)
                         : $this->createServiceLink($relatedDowntime->service, $relatedDowntime->host, true))
-                        ->addAttributes(['class' => 'subject'])
                 ))
             ));
         }


### PR DESCRIPTION
Also fixes a theoretical error, as `createServiceLink`
returns a `FormattedString` which has no attributes.