### PR TITLE
services/grid: Cleanup column aliases

### DIFF
--- a/application/controllers/ServicesController.php
+++ b/application/controllers/ServicesController.php
@@ -267,24 +267,24 @@ class ServicesController extends Controller
             'host.id',
             'host_name' => 'host.name',
             'host_display_name' => 'host.display_name',
-            'service_name' => 'service.name',
-            'service_display_name' => 'service.display_name',
-            'service_handled' => 'service.state.is_handled',
-            'service_output' => 'service.state.output',
-            'service_state' => 'service.state.soft_state'
+            'name' => 'service.name',
+            'display_name' => 'service.display_name',
+            'service.state.is_handled',
+            'service.state.output',
+            'service.state.soft_state'
         ];
 
         if ($flipped) {
-            $pivot = (new PivotTable($query, 'host_name', 'service_name', $columns))
+            $pivot = (new PivotTable($query, 'host_name', 'name', $columns))
                 ->setXAxisFilter($pivotFilter)
                 ->setYAxisFilter($pivotFilter ? clone $pivotFilter : null)
                 ->setXAxisHeader('host_display_name')
-                ->setYAxisHeader('service_display_name');
+                ->setYAxisHeader('display_name');
         } else {
-            $pivot = (new PivotTable($query, 'service_name', 'host_name', $columns))
+            $pivot = (new PivotTable($query, 'name', 'host_name', $columns))
                 ->setXAxisFilter($pivotFilter)
                 ->setYAxisFilter($pivotFilter ? clone $pivotFilter : null)
-                ->setXAxisHeader('service_display_name')
+                ->setXAxisHeader('display_name')
                 ->setYAxisHeader('host_display_name');
         }
 

--- a/application/views/scripts/services/grid-flipped.phtml
+++ b/application/views/scripts/services/grid-flipped.phtml
@@ -71,9 +71,9 @@ foreach ($pivotData as $serviceDescription => $_) {
             if ($service === null): ?>
                 <span aria-hidden="true">&middot;</span>
                 <?php continue; endif ?>
-            <?php $ariaDescribedById = $this->protectId($service->host_name . '_' . $service->service_name . '_desc') ?>
+            <?php $ariaDescribedById = $this->protectId($service->host_name . '_' . $service->name . '_desc') ?>
                 <span class="sr-only" id="<?= $ariaDescribedById ?>">
-                    <?= $this->escape($service->service_output) ?>
+                    <?= $this->escape($service->state->output) ?>
                 </span>
                 <?= $this->qlink(
                     '',
@@ -86,11 +86,11 @@ foreach ($pivotData as $serviceDescription => $_) {
                         'aria-describedby'    => $ariaDescribedById,
                         'aria-label'          => sprintf(
                             $this->translate('Show detailed information for service %s on host %s'),
-                            $service->service_display_name,
+                            $service->display_name,
                             $service->host_display_name
                         ),
-                        'class'               => 'service-grid-link state-' . ServiceStates::text($service->service_state) . ($service->service_handled === 'y' ? ' handled' : ''),
-                        'title'               => $service->service_output
+                        'class'               => 'service-grid-link state-' . $service->state->getStateText() . ($service->state->is_handled === 'y' ? ' handled' : ''),
+                        'title'               => $service->state->output
                     )
                 ) ?>
             </td>

--- a/application/views/scripts/services/grid.phtml
+++ b/application/views/scripts/services/grid.phtml
@@ -73,9 +73,9 @@ foreach ($pivotData as $hostName => $_) {
                 <span aria-hidden="true">&middot;</span>
             <?php continue; endif ?>
                 <?php
-                $ariaDescribedById = $this->protectId($service->host_name . '_' . $service->service_name . '_desc') ?>
+                $ariaDescribedById = $this->protectId($service->host_name . '_' . $service->name . '_desc') ?>
                 <span class="sr-only" id="<?= $ariaDescribedById ?>">
-                    <?= $this->escape($service->service_output) ?>
+                    <?= $this->escape($service->state->output) ?>
                 </span>
                 <?= $this->qlink(
                     '',
@@ -88,11 +88,11 @@ foreach ($pivotData as $hostName => $_) {
                         'aria-describedby'    => $ariaDescribedById,
                         'aria-label'          => sprintf(
                             $this->translate('Show detailed information for service %s on host %s'),
-                            $service->service_display_name,
+                            $service->display_name,
                             $service->host_display_name
                         ),
-                        'class'               => 'service-grid-link state-' . ServiceStates::text($service->service_state) . ($service->service_handled === 'y' ? ' handled' : ''),
-                        'title'               => $service->service_output
+                        'class'               => 'service-grid-link state-' . $service->state->getStateText() . ($service->state->is_handled === 'y' ? ' handled' : ''),
+                        'title'               => $service->state->output
                     )
                 ) ?>
             </td>


### PR DESCRIPTION
Ensures compatibility with Icinga/ipl-orm#52. Backwards compatibility is still the case.