### PR TITLE
Avoid duplicate column suggestions in search bar

### DIFF
--- a/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
+++ b/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
@@ -181,7 +181,6 @@ class ObjectSuggestions extends Suggestions
         $model = $this->getModel();
         $query = $model::on($this->getDb());
 
-        // Ordinary columns first
         foreach (self::collectFilterColumns($model, $query->getResolver()) as $columnName => $columnMeta) {
             yield $columnName => $columnMeta;
         }
@@ -296,9 +295,9 @@ class ObjectSuggestions extends Suggestions
             self::collectRelations($resolver, $model, $models, []);
         }
 
-        foreach ($models as $path => $model) {
-            /** @var Model $model */
-            foreach ($resolver->getColumnDefinitions($model) as $columnName => $definition) {
+        foreach ($models as $path => $targetModel) {
+            /** @var Model $targetModel */
+            foreach ($resolver->getColumnDefinitions($targetModel) as $columnName => $definition) {
                 yield $path . '.' . $columnName => $definition->getLabel();
             }
         }
@@ -368,8 +367,11 @@ class ObjectSuggestions extends Suggestions
                 }
 
                 $relationPath = array_merge($path, $relationPath);
-                $models[join('.', $relationPath)] = $relation->getTarget();
-                self::collectRelations($resolver, $relation->getTarget(), $models, $relationPath);
+
+                if (! in_array($relation->getTarget(), $models)) {
+                    $models[join('.', $relationPath)] = $relation->getTarget();
+                    self::collectRelations($resolver, $relation->getTarget(), $models, $relationPath);
+                }
             }
         }
     }


### PR DESCRIPTION
 `ObjectSuggestions::collectFilterColumns()` returns duplicate column names due to the sub-relations of the joined models. Hence, `ObjectSuggestions::fetchColumnSuggestions()` returns duplicate suggestions for column names for the search bar. This fix solves this issue by resolving the redefinition of the method parameter `$model` in `ObjectSuggestions::collectFilterColumns()` and not registering the duplicate models in `ObjectSuggestions::collectRelations()`.

fix #534 