### PR TITLE
Show host badges in objects-detail for multi-selected hosts

### DIFF
--- a/library/Icingadb/Widget/Detail/ObjectsDetail.php
+++ b/library/Icingadb/Widget/Detail/ObjectsDetail.php
@@ -72,7 +72,7 @@ class ObjectsDetail extends BaseHtmlElement
                     tp('Host', 'Hosts', $this->summary->hosts_total),
                     $this->summary->hosts_total
                 ),
-                new HostStateBadges($badges)
+                $badges
             ]);
         } else {
             $servicesChart = (new Donut())


### PR DESCRIPTION
Icingadb hosts are not showing the host state badges in the detail view upon multi-select. This fix solves the issue.

## Before
![Screenshot 2022-06-22 at 14 46 49](https://user-images.githubusercontent.com/33730024/175032876-46788b25-b27d-4b15-becd-4831e8bcb163.png)



## After
![Screenshot 2022-06-22 at 14 48 16](https://user-images.githubusercontent.com/33730024/175032905-d862dad7-18ee-479f-b49d-56425f236064.png)

