### PR TITLE
ApplicationState: Check the availability of `IcingaRedis` first

### DIFF
--- a/library/Icingadb/ProvidedHook/RedisHealth.php
+++ b/library/Icingadb/ProvidedHook/RedisHealth.php
@@ -48,7 +48,7 @@ class RedisHealth extends HealthHook
                 $this->setMessage(t('Icinga Redis outdated. Make sure Icinga 2 is running and connected to Redis.'));
             }
         } catch (Exception $e) {
-            $this->setState(self::STATE_UNKNOWN);
+            $this->setState(self::STATE_CRITICAL);
             $this->setMessage(sprintf(t("Can't connect to Icinga Redis: %s"), $e->getMessage()));
         }
     }


### PR DESCRIPTION
When icinga redis is down, icingadb also shut down after a few minutes.
In this case, the real cause of icingadb being down is that redis is down.
So we should check icinga redis status first.