### PR TITLE
Don't sort perfData which can't be visualized

### DIFF
--- a/library/Icingadb/Widget/Detail/PerfDataTable.php
+++ b/library/Icingadb/Widget/Detail/PerfDataTable.php
@@ -52,6 +52,14 @@ class PerfDataTable extends Table
         uasort(
             $pieChartData,
             function ($a, $b) {
+                if ($a->isVisualizable() && ! $b->isVisualizable()) {
+                    return -1;
+                } elseif (! $a->isVisualizable() && $b->isVisualizable()) {
+                    return 1;
+                } elseif (! $a->isVisualizable() && ! $b->isVisualizable()) {
+                    return 0;
+                }
+
                 return $a->worseThan($b) ? -1 : ($b->worseThan($a) ? 1 : 0);
             }
         );


### PR DESCRIPTION
This ensures that all perfdata which can't be visualized are rendered exactly in the
same order they are stored in the database after all vizualizable perfData are rendered.

fixes #562