### PR TITLE
Don't use `columns()` of ipl/sql to specify columns to be selected

### DIFF
--- a/library/Icingadb/Authentication/ObjectAuthorization.php
+++ b/library/Icingadb/Authentication/ObjectAuthorization.php
@@ -120,7 +120,6 @@ class ObjectAuthorization
             $query
                 ->filter($filter)
                 ->filter(Filter::equal($object->getKeyName(), $uniqueId))
-                ->getSelectBase()
                 ->columns([new Expression('1')]);
 
             $result = $query->execute()->hasResult();


### PR DESCRIPTION
The `Sql::columns()` method doesn't override existing columns when calling this directly, because
at this point the ipl/orm query has already collected all selectable columns, which are not required
for this use case. A later call to the `columns()` method using the select base doesn't prevent all the
columns registered by the query from being selected.