### PR TITLE
Docs/About: Remove link to license

### DIFF
--- a/doc/01-About.md
+++ b/doc/01-About.md
@@ -61,4 +61,4 @@ To install Icinga DB Web see [Installation](02-Installation.md).
 ## License
 
 Icinga DB Web and the Icinga DB Web documentation are licensed under the terms of the
-[GNU General Public License Version 2](../LICENSE).
+GNU General Public License Version 2.


### PR DESCRIPTION
Our tooling for icinga.com/docs fails to parse this link properly.