### PR TITLE
Sort also pie charts in detailed view mode

### DIFF
--- a/library/Icingadb/Util/PerfDataSet.php
+++ b/library/Icingadb/Util/PerfDataSet.php
@@ -88,6 +88,21 @@ class PerfDataSet implements IteratorAggregate
                 $this->perfdata[] = new PerfData($label, $value);
             }
         }
+
+        uasort(
+            $this->perfdata,
+            function ($a, $b) {
+                if ($a->isVisualizable() && ! $b->isVisualizable()) {
+                    return -1;
+                } elseif (! $a->isVisualizable() && $b->isVisualizable()) {
+                    return 1;
+                } elseif (! $a->isVisualizable() && ! $b->isVisualizable()) {
+                    return 0;
+                }
+
+                return $a->worseThan($b) ? -1 : ($b->worseThan($a) ? 1 : 0);
+            }
+        );
     }
 
     /**

--- a/library/Icingadb/Widget/Detail/PerfDataTable.php
+++ b/library/Icingadb/Widget/Detail/PerfDataTable.php
@@ -49,20 +49,6 @@ class PerfDataTable extends Table
     public function assemble()
     {
         $pieChartData = PerfDataSet::fromString($this->perfdataStr)->asArray();
-        uasort(
-            $pieChartData,
-            function ($a, $b) {
-                if ($a->isVisualizable() && ! $b->isVisualizable()) {
-                    return -1;
-                } elseif (! $a->isVisualizable() && $b->isVisualizable()) {
-                    return 1;
-                } elseif (! $a->isVisualizable() && ! $b->isVisualizable()) {
-                    return 0;
-                }
-
-                return $a->worseThan($b) ? -1 : ($b->worseThan($a) ? 1 : 0);
-            }
-        );
         $keys = ['', 'label', 'value', 'min', 'max', 'warn', 'crit'];
         $columns = [];
         $labels = array_combine(


### PR DESCRIPTION
At the moment we only render the sorted perfData in the object details, but when switching to
the detailed view mode the same perfData are rendered unsorted. This PR ensures that the perfData
are also sorted once after they have been successfully parsed.