### PR TITLE
Change `overflow` property to `overflow-x` in `performance-data-table` class

### DIFF
--- a/public/css/widget/performance-data-table.less
+++ b/public/css/widget/performance-data-table.less
@@ -2,7 +2,7 @@
 
 .performance-data-table {
   width: 100%;
-  overflow: auto;
+  overflow-x: auto;
   display: block;
 
   tr:not(:last-child) {


### PR DESCRIPTION
Since the vertical scrolling must disabled upon clip, only `overflow-x` property is set to `auto`. Similar to `performance-data-table` class in monitoring module.
This fix disables the vertical scrolling in the `performance-data-table` when it overflows.

fixes #581 