### PR TITLE
Introduce new restriction `icingadb/scope/commands`

### DIFF
--- a/configuration.php
+++ b/configuration.php
@@ -103,6 +103,11 @@ namespace Icinga\Module\Icingadb {
     );
 
     $this->provideRestriction(
+        'icingadb/scope/commands',
+        $this->translate('Restrict to which objects the command permissions this role grants will apply')
+    );
+
+    $this->provideRestriction(
         'icingadb/filter/objects',
         $this->translate('Restrict access to the Icinga objects that match the filter')
     );

--- a/doc/04-Security.md
+++ b/doc/04-Security.md
@@ -9,8 +9,8 @@ The same applies to routes, objects and variables. To these, users can be restri
 
 > **Restricted Command Permissions:**
 >
-> If a role [limits users](#filters) to a specific set of results, the command
-> permissions or refusals of the very same role only apply to these results.
+> If a role [limits users](#filters) to a specific set of results, the granted command permissions of the very same
+> role only apply to these results. The [`icingadb/scope/commands`](#scopes) restriction has the same effect.
 
 | Name                                           | Allow...                                                                         |
 |------------------------------------------------|----------------------------------------------------------------------------------|
@@ -59,6 +59,17 @@ not just hosts or services. It should be one or more [filter expressions](#filte
 unrestricted. It should be one or more [filter expressions](#filter-expressions).
 
 `icingadb/filter/services` will only allow users to access matching services. Other objects remain unrestricted.
+It should be one or more [filter expressions](#filter-expressions).
+
+### Scopes
+
+Scopes don't limit users in what they can see, just in what they can do where.
+
+| Name                    | Description                                                                |
+|-------------------------|----------------------------------------------------------------------------|
+| icingadb/scope/commands | Restrict to which objects the command permissions a role grants will apply |
+
+`icingadb/scope/commands` will limit where the granted command permissions of a role will apply.
 It should be one or more [filter expressions](#filter-expressions).
 
 ### Denylists

--- a/library/Icingadb/Authentication/ObjectAuthorization.php
+++ b/library/Icingadb/Authentication/ObjectAuthorization.php
@@ -153,6 +153,10 @@ class ObjectAuthorization
 
         foreach ($this->getAuth()->getUser()->getRoles() as $role) {
             $roleFilter = Filter::all();
+            if (($restriction = $role->getRestrictions('icingadb/scope/commands'))) {
+                $roleFilter->add($this->parseRestriction($restriction, 'icingadb/scopes/commands'));
+            }
+
             if (($restriction = $role->getRestrictions('icingadb/filter/objects'))) {
                 $roleFilter->add($this->parseRestriction($restriction, 'icingadb/filter/objects'));
             }


### PR DESCRIPTION
I thought this is worthwhile to have. It allows to limit users with a specific set of granted command permissions to certain hosts and services. The difference to the other restrictions is though, that it doesn't affect the visiblity of objects but rather the validity of the granted command permissions only.

This is the same effect that the current restrictions already have. But this allows to set up a role that doesn't limit a user in what's shown and what's not, but where which commands are allowed.