### PR TITLE
Fix pending state balls

### DIFF
--- a/library/Icingadb/Widget/ItemList/StateListItem.php
+++ b/library/Icingadb/Widget/ItemList/StateListItem.php
@@ -82,7 +82,6 @@ abstract class StateListItem extends BaseListItem
             $stateBall->getAttributes()->add('class', 'handled');
         } elseif ($this->state->getStateText() === 'pending' && $this->state->in_downtime) {
             $stateBall->addHtml(new Icon($this->getHandledIcon()));
-            $stateBall->getAttributes()->add('class', 'handled');
         }
 
         $visual->addHtml($stateBall);

--- a/library/Icingadb/Widget/ItemList/StateListItem.php
+++ b/library/Icingadb/Widget/ItemList/StateListItem.php
@@ -80,6 +80,9 @@ abstract class StateListItem extends BaseListItem
         if ($this->state->is_handled) {
             $stateBall->addHtml(new Icon($this->getHandledIcon()));
             $stateBall->getAttributes()->add('class', 'handled');
+        } elseif ($this->state->getStateText() === 'pending' && $this->state->in_downtime) {
+            $stateBall->addHtml(new Icon($this->getHandledIcon()));
+            $stateBall->getAttributes()->add('class', 'handled');
         }
 
         $visual->addHtml($stateBall);

--- a/public/css/widget/state-change.less
+++ b/public/css/widget/state-change.less
@@ -53,7 +53,8 @@
   }
 
   .state-ball.state-ok,
-  .state-ball.state-up {
+  .state-ball.state-up,
+  .state-pending {
     &.ball-size-l,
     &.ball-size-xl {
       background-color: @body-bg-color;


### PR DESCRIPTION
 `pending` state balls will be represented as hollowed state balls instead of solid state balls (ipl-web@3bccdd0da71a178fc0b10422275bfee8c4d3f4a4). Hence, `pending` state balls must behave similarly as `ok` or `up` upon change in state of the object.

Also, in case a downtime is scheduled for `pending` objects, their state balls must contain `plug` icon.

depends on icinga/ipl-web#90