### PR TITLE
Utilize enhanced search constraints

### DIFF
--- a/library/Icingadb/Model/Comment.php
+++ b/library/Icingadb/Model/Comment.php
@@ -8,6 +8,7 @@ use Icinga\Module\Icingadb\Model\Behavior\BoolCast;
 use Icinga\Module\Icingadb\Model\Behavior\ReRoute;
 use Icinga\Module\Icingadb\Model\Behavior\Timestamp;
 use ipl\Orm\Behavior\Binary;
+use ipl\Orm\Behavior\NonTextMatch;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Model;
 use ipl\Orm\Relations;
@@ -57,7 +58,14 @@ class Comment extends Model
             'name'                  => t('Comment Name'),
             'author'                => t('Comment Author'),
             'text'                  => t('Comment Text'),
-            'entry_type'            => t('Comment Type'),
+            'entry_type'            => [
+                'label' => t('Comment Type'),
+                'type' => 'enum',
+                'allowed_values' => [
+                    'comment' => t('Comment'),
+                    'ack' => t('Acknowledgement')
+                ]
+            ],
             'entry_time'            => t('Comment Entry Time'),
             'is_persistent'         => t('Comment Is Persistent'),
             'is_sticky'             => t('Comment Is Sticky'),
@@ -102,6 +110,8 @@ class Comment extends Model
             'properties_checksum',
             'zone_id'
         ]));
+
+        $behaviors->add(new NonTextMatch());
     }
 
     public function createRelations(Relations $relations)

--- a/library/Icingadb/Model/ServiceState.php
+++ b/library/Icingadb/Model/ServiceState.php
@@ -23,12 +23,22 @@ class ServiceState extends State
     {
         return [
             'environment_id'                => t('Environment Id'),
-            'state_type'                    => t('Service State Type'),
+            'state_type'                    => [
+                'label' => t('Service State Type'),
+                'type' => 'enum',
+                'allowed_values' => [
+                    'hard' => t('Hard'),
+                    'soft' => t('Soft')
+                ]
+            ],
             'soft_state'                    => t('Service Soft State'),
             'hard_state'                    => t('Service Hard State'),
             'previous_soft_state'           => t('Service Previous Soft State'),
             'previous_hard_state'           => t('Service Previous Hard State'),
-            'check_attempt'                 => t('Service Check Attempt No.'),
+            'check_attempt'                 => [
+                'label' => t('Service Check Attempt No.'),
+                'type' => 'number'
+            ],
             'severity'                      => t('Service State Severity'),
             'output'                        => t('Service Output'),
             'long_output'                   => t('Service Long Output'),

--- a/library/Icingadb/Model/State.php
+++ b/library/Icingadb/Model/State.php
@@ -7,6 +7,7 @@ namespace Icinga\Module\Icingadb\Model;
 use Icinga\Module\Icingadb\Model\Behavior\BoolCast;
 use Icinga\Module\Icingadb\Model\Behavior\Timestamp;
 use ipl\Orm\Behavior\Binary;
+use ipl\Orm\Behavior\NonTextMatch;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Model;
 
@@ -79,5 +80,7 @@ abstract class State extends Model
             'acknowledgement_comment_id',
             'last_comment_id'
         ]));
+
+        $behaviors->add(new NonTextMatch());
     }
 }

--- a/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
+++ b/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
@@ -16,6 +16,7 @@ use ipl\Html\HtmlElement;
 use ipl\Orm\Exception\InvalidColumnException;
 use ipl\Orm\Exception\InvalidRelationException;
 use ipl\Orm\Model;
+use ipl\Orm\Query;
 use ipl\Orm\Relation;
 use ipl\Orm\Relation\BelongsToMany;
 use ipl\Orm\Relation\HasOne;
@@ -36,6 +37,9 @@ class ObjectSuggestions extends Suggestions
 
     /** @var Model */
     protected $model;
+
+    /** @var Query */
+    protected $query;
 
     /** @var array */
     protected $customVarSources;
@@ -91,6 +95,15 @@ class ObjectSuggestions extends Suggestions
         return $this->model;
     }
 
+    public function getQuery(): Query
+    {
+        if ($this->query === null) {
+            $this->query = ($this->getModel())::on($this->getDb());
+        }
+
+        return $this->query;
+    }
+
     protected function shouldShowRelationFor(string $column): bool
     {
         if (strpos($column, '.vars.') !== false) {
@@ -131,7 +144,7 @@ class ObjectSuggestions extends Suggestions
     protected function fetchValueSuggestions($column, $searchTerm, Filter\Chain $searchFilter)
     {
         $model = $this->getModel();
-        $query = $model::on($this->getDb());
+        $query = $this->getQuery();
         $query->limit(static::DEFAULT_LIMIT);
 
         if (strpos($column, ' ') !== false) {
@@ -202,7 +215,7 @@ class ObjectSuggestions extends Suggestions
     protected function fetchColumnSuggestions($searchTerm)
     {
         $model = $this->getModel();
-        $query = $model::on($this->getDb());
+        $query = $this->getQuery();
 
         // Ordinary columns first
         foreach (self::collectFilterColumns($model, $query->getResolver()) as $columnName => $columnMeta) {


### PR DESCRIPTION
This is far from finished. Only a few select columns have constraints currently:

* `comment.entry_type`
* `service.state.state_type`
* `service.state.check_attempt`

With postgresql the full effect can only be observed by dropping the custom operator (`~~ anynonarray`) from the schema.

requires https://github.com/Icinga/ipl-orm/pull/71
requires https://github.com/Icinga/ipl-web/pull/92