### PR TITLE
Don't strictly check whether `hGet` returns false

### DIFF
--- a/library/Icingadb/Common/ObjectInspectionDetail.php
+++ b/library/Icingadb/Common/ObjectInspectionDetail.php
@@ -116,7 +116,7 @@ abstract class ObjectInspectionDetail extends BaseHtmlElement
             return [$title, sprintf('Failed to load redis data: %s', $e->getMessage())];
         }
 
-        if ($json === false) {
+        if (! $json) {
             return [$title, new EmptyState(t('No data available in redis'))];
         }
 


### PR DESCRIPTION
Nowadays hGet returns null instead of false if there is no data available yet.
But since we are performing strict comparison on false, it won't enter the if branch anymore.
There is another Predis client method we use which is `hmGet`, but as usual it still returns only an array.

fixes #606