### PR TITLE
BaseHistoryListItem: Don't pass null values to `MarkdownLine` class

### DIFF
--- a/library/Icingadb/Widget/ItemList/BaseHistoryListItem.php
+++ b/library/Icingadb/Widget/ItemList/BaseHistoryListItem.php
@@ -100,7 +100,7 @@ abstract class BaseHistoryListItem extends BaseListItem
                 break;
             case 'ack_clear':
             case 'ack_set':
-                $markdownLine = new MarkdownLine($this->item->acknowledgement->comment);
+                $markdownLine = new MarkdownLine($this->item->acknowledgement->comment ?? '');
                 $caption->getAttributes()->add($markdownLine->getAttributes());
                 $caption->add([
                     new Icon(Icons::USER),


### PR DESCRIPTION
I have also checked the other columns that can contain null values like this column,
however they are not affected by such bug. So, the way they are currently being used
does not cause such an error.