### PR TITLE
Replace deprecated hook `Icinga\Web\Hook` with `Icinga\Application\Hook`

### DIFF
--- a/application/controllers/MigrateController.php
+++ b/application/controllers/MigrateController.php
@@ -6,12 +6,12 @@ namespace Icinga\Module\Icingadb\Controllers;
 
 use Exception;
 use GuzzleHttp\Psr7\ServerRequest;
+use Icinga\Application\Hook;
 use Icinga\Exception\IcingaException;
 use Icinga\Module\Icingadb\Compat\UrlMigrator;
 use Icinga\Module\Icingadb\Forms\SetAsBackendForm;
 use Icinga\Module\Icingadb\Hook\IcingadbSupportHook;
 use Icinga\Module\Icingadb\Web\Controller;
-use Icinga\Web\Hook;
 use ipl\Html\HtmlString;
 use ipl\Web\Url;
 

--- a/library/Icingadb/Hook/ExtensionHook/ObjectDetailExtensionHook.php
+++ b/library/Icingadb/Hook/ExtensionHook/ObjectDetailExtensionHook.php
@@ -5,6 +5,7 @@
 namespace Icinga\Module\Icingadb\Hook\ExtensionHook;
 
 use Exception;
+use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 use Icinga\Exception\IcingaException;
 use Icinga\Module\Icingadb\Hook\EventDetailExtensionHook;
@@ -17,7 +18,6 @@ use Icinga\Module\Icingadb\Model\Host;
 use Icinga\Module\Icingadb\Model\Service;
 use Icinga\Module\Icingadb\Model\User;
 use Icinga\Module\Icingadb\Model\Usergroup;
-use Icinga\Web\Hook;
 use InvalidArgumentException;
 use ipl\Html\Attributes;
 use ipl\Html\HtmlElement;

--- a/library/Icingadb/Hook/ExtensionHook/ObjectsDetailExtensionHook.php
+++ b/library/Icingadb/Hook/ExtensionHook/ObjectsDetailExtensionHook.php
@@ -5,12 +5,12 @@
 namespace Icinga\Module\Icingadb\Hook\ExtensionHook;
 
 use Exception;
+use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 use Icinga\Exception\IcingaException;
 use Icinga\Module\Icingadb\Common\BaseFilter;
 use Icinga\Module\Icingadb\Hook\HostsDetailExtensionHook;
 use Icinga\Module\Icingadb\Hook\ServicesDetailExtensionHook;
-use Icinga\Web\Hook;
 use InvalidArgumentException;
 use ipl\Html\Attributes;
 use ipl\Html\HtmlElement;

--- a/library/Icingadb/Hook/TabHook/HookActions.php
+++ b/library/Icingadb/Hook/TabHook/HookActions.php
@@ -6,9 +6,9 @@ namespace Icinga\Module\Icingadb\Hook\TabHook;
 
 use Exception;
 use Generator;
+use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 use Icinga\Module\Icingadb\Hook\TabHook;
-use Icinga\Web\Hook;
 use ipl\Html\ValidHtml;
 use ipl\Orm\Model;
 use ipl\Stdlib\Str;

--- a/library/Icingadb/Widget/Detail/ObjectDetail.php
+++ b/library/Icingadb/Widget/Detail/ObjectDetail.php
@@ -6,6 +6,7 @@ namespace Icinga\Module\Icingadb\Widget\Detail;
 
 use Exception;
 use Icinga\Application\ClassLoader;
+use Icinga\Application\Hook;
 use Icinga\Application\Hook\GrapherHook;
 use Icinga\Application\Icinga;
 use Icinga\Application\Logger;
@@ -39,7 +40,6 @@ use Icinga\Module\Icingadb\Widget\PluginOutputContainer;
 use Icinga\Module\Icingadb\Widget\ShowMore;
 use Icinga\Module\Icingadb\Widget\TagList;
 use Icinga\Module\Monitoring\Hook\DetailviewExtensionHook;
-use Icinga\Web\Hook;
 use Icinga\Web\Navigation\Navigation;
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;


### PR DESCRIPTION
The deprecated hook `Icinga\Web\Hook` is replaced with `Icinga\Application\Hook` where ever  it is used.