### PR TITLE
css: Prevent scrollbars to appear if icon images are large

### DIFF
--- a/public/css/list/item-list.less
+++ b/public/css/list/item-list.less
@@ -201,6 +201,7 @@
     text-align: center;
     margin-top: .5em;
     margin-left: .5em;
+    overflow: hidden;
 
     img {
       max-height: 100%;


### PR DESCRIPTION
fixes #633