### PR TITLE
Change the order of handled state icons

### DIFF
--- a/library/Icingadb/Widget/ItemList/StateListItem.php
+++ b/library/Icingadb/Widget/ItemList/StateListItem.php
@@ -107,10 +107,10 @@ abstract class StateListItem extends BaseListItem
     protected function getHandledIcon(): string
     {
         switch (true) {
-            case $this->state->in_downtime:
-                return Icons::IN_DOWNTIME;
             case $this->state->is_acknowledged:
                 return Icons::IS_ACKNOWLEDGED;
+            case $this->state->in_downtime:
+                return Icons::IN_DOWNTIME;
             case $this->state->is_flapping:
                 return Icons::IS_FLAPPING;
             default:


### PR DESCRIPTION
In case of handled hosts/services acknowledged state must be give priority over downtime and downtime
should be given priority over flapping. So the order for the handled state icons  must be
acknowledged, downtime or flapping respectively.

## Before
![Screenshot 2022-09-05 at 11 58 38](https://user-images.githubusercontent.com/33730024/188423859-8437b752-5050-42d1-b2ed-5de4c971a3e9.png)

## After
![Screenshot 2022-09-05 at 11 58 56](https://user-images.githubusercontent.com/33730024/188423893-88329f26-350a-47ae-ac88-b2be2d074847.png)
