### PR TITLE
Fix/SetApiTimeout

### DIFF
--- a/library/Icingadb/Command/Transport/ApiCommandTransport.php
+++ b/library/Icingadb/Command/Transport/ApiCommandTransport.php
@@ -311,7 +311,7 @@ class ApiCommandTransport implements CommandTransportInterface
     public function probe()
     {
         try {
-            $response = (new Client(['timeout' => 15 ]))
+            $response = (new Client(['timeout' =>15]))
                 ->get($this->getUriFor(''), [
                     'auth'          => [$this->getUsername(), $this->getPassword()],
                     'headers'       => ['Accept' => 'application/json'],

--- a/library/Icingadb/Command/Transport/ApiCommandTransport.php
+++ b/library/Icingadb/Command/Transport/ApiCommandTransport.php
@@ -311,7 +311,7 @@ class ApiCommandTransport implements CommandTransportInterface
     public function probe()
     {
         try {
-            $response = (new Client(['timeout' => '15']))
+            $response = (new Client(['timeout' => 15 ]))
                 ->get($this->getUriFor(''), [
                     'auth'          => [$this->getUsername(), $this->getPassword()],
                     'headers'       => ['Accept' => 'application/json'],

--- a/library/Icingadb/Command/Transport/ApiCommandTransport.php
+++ b/library/Icingadb/Command/Transport/ApiCommandTransport.php
@@ -311,7 +311,7 @@ class ApiCommandTransport implements CommandTransportInterface
     public function probe()
     {
         try {
-            $response = (new Client())
+            $response = (new Client(['timeout' => '15']))
                 ->get($this->getUriFor(''), [
                     'auth'          => [$this->getUsername(), $this->getPassword()],
                     'headers'       => ['Accept' => 'application/json'],

--- a/library/Icingadb/Command/Transport/ApiCommandTransport.php
+++ b/library/Icingadb/Command/Transport/ApiCommandTransport.php
@@ -311,7 +311,7 @@ class ApiCommandTransport implements CommandTransportInterface
     public function probe()
     {
         try {
-            $response = (new Client(['timeout' =>15]))
+            $response = (new Client(['timeout' => 15 ]))
                 ->get($this->getUriFor(''), [
                     'auth'          => [$this->getUsername(), $this->getPassword()],
                     'headers'       => ['Accept' => 'application/json'],

--- a/library/Icingadb/Command/Transport/ApiCommandTransport.php
+++ b/library/Icingadb/Command/Transport/ApiCommandTransport.php
@@ -311,7 +311,7 @@ class ApiCommandTransport implements CommandTransportInterface
     public function probe()
     {
         try {
-            $response = (new Client(['timeout' => 15 ]))
+            $response = (new Client(['timeout' => 15]))
                 ->get($this->getUriFor(''), [
                     'auth'          => [$this->getUsername(), $this->getPassword()],
                     'headers'       => ['Accept' => 'application/json'],


### PR DESCRIPTION
Trying to connect to the API, there is no default timeout specified. This one sets a debatable one with 15 seconds, whereas monitoring has 30s. 