### PR TITLE
Database: Only use `PDO::MYSQL_ATTR_INIT_COMMAND` for mysql connections

### DIFF
--- a/library/Icingadb/Common/Database.php
+++ b/library/Icingadb/Common/Database.php
@@ -34,11 +34,11 @@ trait Database
                 AppConfig::module('icingadb')->get('icingadb', 'resource')
             ));
 
-            $config->options = [
-                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_OBJ,
-                PDO::MYSQL_ATTR_INIT_COMMAND => "SET SESSION SQL_MODE='STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE"
-                    . ",ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'"
-            ];
+            $config->options = [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_OBJ];
+            if ($config->db === 'mysql') {
+                $config->options[PDO::MYSQL_ATTR_INIT_COMMAND] = "SET SESSION SQL_MODE='STRICT_TRANS_TABLES"
+                    . ",NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
+            }
 
             $this->db = new Connection($config);
 


### PR DESCRIPTION
fixes #647