### PR TITLE
Avoid accessing non-existent last comment

### DIFF
--- a/library/Icingadb/Widget/ItemList/HostListItemDetailed.php
+++ b/library/Icingadb/Widget/ItemList/HostListItemDetailed.php
@@ -31,7 +31,7 @@ class HostListItemDetailed extends BaseHostListItem
     {
         $statusIcons = new HtmlElement('div', Attributes::create(['class' => 'status-icons']));
 
-        if ($this->item->state->last_comment_id !== null) {
+        if ($this->item->state->last_comment->host_id === $this->item->id) {
             $comment = $this->item->state->last_comment;
             $comment->host = $this->item;
             $comment = (new CommentList([$comment]))

--- a/library/Icingadb/Widget/ItemList/ServiceListItemDetailed.php
+++ b/library/Icingadb/Widget/ItemList/ServiceListItemDetailed.php
@@ -31,7 +31,7 @@ class ServiceListItemDetailed extends BaseServiceListItem
     {
         $statusIcons = new HtmlElement('div', Attributes::create(['class' => 'status-icons']));
 
-        if ($this->item->state->last_comment_id !== null) {
+        if ($this->item->state->last_comment->service_id === $this->item->id) {
             $comment = $this->item->state->last_comment;
             $comment->service = $this->item;
             $comment = (new CommentList([$comment]))


### PR DESCRIPTION
The `last_comment` relation is joined by the base query. This causes the underlying model to have nulled properties if the `last_comment_id` is set but the comment is not yet written to database.

closes #659