### PR TITLE
EventDetail: Use `'UTC'` instead of `DateTimeZone::UTC`

### DIFF
--- a/library/Icingadb/Widget/Detail/EventDetail.php
+++ b/library/Icingadb/Widget/Detail/EventDetail.php
@@ -521,7 +521,7 @@ class EventDetail extends BaseHtmlElement
             } else {
                 $expired = false;
                 if ($acknowledgement->expire_time) {
-                    $now = (new DateTime())->setTimezone(new DateTimeZone(DateTimeZone::UTC));
+                    $now = (new DateTime())->setTimezone(new DateTimeZone('UTC'));
                     $expiresOn = clone $now;
                     $expiresOn->setTimestamp($acknowledgement->expire_time);
                     if ($now <= $expiresOn) {


### PR DESCRIPTION
Not sure why this worked previously, but `DateTimeZone::__construct()` only accepts strings anyway :man_shrugging: 

fixes #667