### PR TITLE
Reporting Module: E-Mail Provider

### DIFF
--- a/library/Icingadb/ProvidedHook/Reporting/EmailProvider.php
+++ b/library/Icingadb/ProvidedHook/Reporting/EmailProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Icinga\Module\Icingadb\ProvidedHook\Reporting;
+
+use Icinga\Exception\ConfigurationError;
+use Icinga\Module\Icingadb\Common\Database;
+use Icinga\Module\Icingadb\Model\User;
+use Icinga\Module\Reporting\Hook\EmailProviderHook;
+
+class EmailProvider extends EmailProviderHook
+{
+    use Database;
+
+    /**
+     * @return array
+     * @throws ConfigurationError
+     */
+    public function getContactEmails(): array
+    {
+        $emails = [];
+
+        foreach (User::on($this->getDb()) as $user) {
+            $emails[$user['email']] = $user['display_name'];
+        }
+
+        return $emails;
+    }
+}

--- a/run.php
+++ b/run.php
@@ -10,6 +10,7 @@ $this->provideHook('health', 'IcingaHealth');
 $this->provideHook('health', 'RedisHealth');
 $this->provideHook('Reporting/Report', 'Reporting/HostSlaReport');
 $this->provideHook('Reporting/Report', 'Reporting/ServiceSlaReport');
+$this->provideHook('Reporting/EmailProvider', 'Reporting/EmailProvider');
 
 if (! $this::exists('monitoring')) {
     $modulePath = null;


### PR DESCRIPTION
Implements the `EmailProviderHook` from the Reporting Module to show all User's Emails in a list for sending Reports.

depends on: https://github.com/Icinga/icingaweb2-module-reporting/pull/158