### PR TITLE
Fix Error when dealing with wrong PerfData

### DIFF
--- a/library/Icingadb/Util/PerfData.php
+++ b/library/Icingadb/Util/PerfData.php
@@ -312,7 +312,8 @@ class PerfData
      */
     public function isVisualizable(): bool
     {
-        return isset($this->minValue) && isset($this->maxValue) && isset($this->value);
+        return is_numeric($this->minValue ?? null) && is_numeric($this->maxValue ?? null)
+            && is_numeric($this->value ?? null);
     }
 
     /**


### PR DESCRIPTION
If the perf data is not valid (e.g. `needrestart -p` with unknown values), a "non-numeric value encountered" error is thrown. This patch makes the check more specific to catch this error as well.

In our case, we run the `needrestart -p` command on raspbian with this output:

```
root@raspberry ~ # needrestart -p
UNKN - Kernel: 5.15.76-v7+!=5.15.84-v8+ (!!), Microcode: unknown, Services: none, Containers: none, Sessions: none|Kernel=2;0;;0;2 Microcode=U;0;;0;1 Services=0;;0;0 Containers=0;;0;0 Sessions=0;0;;0
```

The "U" in the Microcode value triggers the aforementioned error. The proposed fix should catches this.