### PR TITLE
Fix parsing unknown value in PerfData

### DIFF
--- a/library/Icingadb/Util/PerfData.php
+++ b/library/Icingadb/Util/PerfData.php
@@ -426,11 +426,15 @@ class PerfData
         $parts = explode(';', $this->perfdataValue);
 
         $matches = array();
-        if (preg_match('@^(-?(?:\d+)?(?:\.\d+)?)([a-zA-Z%°]{1,3})$@u', $parts[0], $matches)) {
+        if (preg_match('@^(U|-?(?:\d+)?(?:\.\d+)?)([a-zA-TV-Z%°]{1,3})$@u', $parts[0], $matches)) {
             $this->unit = $matches[2];
             $this->value = $matches[1];
         } else {
             $this->value = $parts[0];
+        }
+
+        if (! is_numeric($this->value)) {
+            $this->value = null;
         }
 
         switch (count($parts)) {


### PR DESCRIPTION
'U' is neither a valid SI unit nor a valid prefix, so excluding it in the UOM part of the regex should not cause any issues.

The UOM regex now also accepts the `μ` prefix. Icinga normalizes values, but the regex seems to try to include them anyway.

If there is no numeric value, the pie chart can't show anything, so we test for that.

closes #700