### PR TITLE
SlaReport: Handle `null` sla results correctly

### DIFF
--- a/library/Icingadb/ProvidedHook/Reporting/SlaReport.php
+++ b/library/Icingadb/ProvidedHook/Reporting/SlaReport.php
@@ -112,6 +112,10 @@ abstract class SlaReport extends ReportHook
             }
         } else {
             foreach ($this->fetchSla($timerange, $filter) as $row) {
+                if ($row->sla === null) {
+                    $row->sla = 0.0;
+                }
+
                 $rows[] = $this->createReportRow($row);
             }
         }


### PR DESCRIPTION
With [this PR](https://github.com/Icinga/icingadb/pull/560) of icingadb the sla might be `null` when generating reports within a timeframe for which no history events can be found, causing a fatal.

### Before
<img width="615" alt="Bildschirm­foto 2023-01-26 um 11 28 45" src="https://user-images.githubusercontent.com/57616252/214813788-ec5c4698-fc4b-4412-8dd0-a9b66d494099.png">


### After
<img width="615" alt="Bildschirm­foto 2023-01-26 um 11 27 50" src="https://user-images.githubusercontent.com/57616252/214813594-ac9f11b7-674a-40d6-b746-2d52bcff790f.png">
