### PR TITLE
`Pagination|History`: Reset query offset on page reload

### DIFF
--- a/application/controllers/HistoryController.php
+++ b/application/controllers/HistoryController.php
@@ -74,6 +74,7 @@ class HistoryController extends Controller
         $page = $paginationControl->getCurrentPageNumber();
 
         if ($page > 1 && ! $compact) {
+            $history->resetOffset();
             $history->limit($page * $limitControl->getLimit());
         }
 

--- a/application/controllers/NotificationsController.php
+++ b/application/controllers/NotificationsController.php
@@ -71,6 +71,7 @@ class NotificationsController extends Controller
         $page = $paginationControl->getCurrentPageNumber();
 
         if ($page > 1 && ! $compact) {
+            $notifications->resetOffset();
             $notifications->limit($page * $limitControl->getLimit());
         }
 


### PR DESCRIPTION
fix #733
Bug exists since: https://github.com/Icinga/icingadb-web/pull/254


The `PaginationControl` always sets the offset. This must be reset when the page is reloaded.