### PR TITLE
Fix confusing `Downtime cancelled` header in event history list

### DIFF
--- a/library/Icingadb/Widget/ItemList/BaseHistoryListItem.php
+++ b/library/Icingadb/Widget/ItemList/BaseHistoryListItem.php
@@ -303,7 +303,7 @@ abstract class BaseHistoryListItem extends BaseListItem
                     } else {
                         $subjectLabel = t('Downtime cancelled by author');
                     }
-                } elseif (isset($this->item->downtime->cancel_time)) {
+                } elseif ($this->item->downtime->has_been_cancelled === 'y') {
                     $subjectLabel = t('Downtime cancelled');
                 } else {
                     $subjectLabel = t('Downtime ended');


### PR DESCRIPTION
If the downtime ends normally it must be displayed `Downtime ended` instead of `Downtime cancelled`.

fix #691 