### PR TITLE
Severity sort must also sort objects by `last_state_change` in descending

### DIFF
--- a/application/controllers/HostsController.php
+++ b/application/controllers/HostsController.php
@@ -54,10 +54,10 @@ class HostsController extends Controller
         $sortControl = $this->createSortControl(
             $hosts,
             [
-                'host.display_name'                 => t('Name'),
-                'host.state.severity desc'          => t('Severity'),
-                'host.state.soft_state'             => t('Current State'),
-                'host.state.last_state_change desc' => t('Last State Change')
+                'host.display_name'                                          => t('Name'),
+                'host.state.severity desc,host.state.last_state_change desc' => t('Severity'),
+                'host.state.soft_state'                                      => t('Current State'),
+                'host.state.last_state_change desc'                          => t('Last State Change')
             ]
         );
         $viewModeSwitcher = $this->createViewModeSwitcher($paginationControl, $limitControl);

--- a/application/controllers/ServicesController.php
+++ b/application/controllers/ServicesController.php
@@ -63,11 +63,11 @@ class ServicesController extends Controller
         $sortControl = $this->createSortControl(
             $services,
             [
-                'service.display_name'                 => t('Name'),
-                'service.state.severity desc'          => t('Severity'),
-                'service.state.soft_state'             => t('Current State'),
-                'service.state.last_state_change desc' => t('Last State Change'),
-                'host.display_name'                    => t('Host')
+                'service.display_name'                                             => t('Name'),
+                'service.state.severity desc,service.state.last_state_change desc' => t('Severity'),
+                'service.state.soft_state'                                         => t('Current State'),
+                'service.state.last_state_change desc'                             => t('Last State Change'),
+                'host.display_name'                                                => t('Host')
             ]
         );
         $viewModeSwitcher = $this->createViewModeSwitcher($paginationControl, $limitControl);


### PR DESCRIPTION
fixes #676 