### PR TITLE
Unset pagination parameters for service grid when `limit=0,0`

### DIFF
--- a/application/controllers/ServicesController.php
+++ b/application/controllers/ServicesController.php
@@ -22,6 +22,7 @@ use Icinga\Module\Icingadb\Widget\ItemTable\ServiceItemTable;
 use Icinga\Module\Icingadb\Widget\ServiceStatusBar;
 use Icinga\Module\Icingadb\Widget\ShowMore;
 use Icinga\Module\Icingadb\Web\Control\ViewModeSwitcher;
+use Icinga\Util\Environment;
 use ipl\Html\HtmlString;
 use ipl\Orm\Query;
 use ipl\Stdlib\Filter;
@@ -222,6 +223,8 @@ class ServicesController extends Controller
 
     public function gridAction()
     {
+        Environment::raiseExecutionTime();
+
         $db = $this->getDb();
         $this->addTitleTab(t('Service Grid'));
 
@@ -298,7 +301,6 @@ class ServicesController extends Controller
                 ->setXAxisHeader('display_name')
                 ->setYAxisHeader('host_display_name');
         }
-
 
         $this->view->horizontalPaginator = $pivot->paginateXAxis();
         $this->view->verticalPaginator = $pivot->paginateYAxis();

--- a/application/views/scripts/joystickPagination-icingadb.phtml
+++ b/application/views/scripts/joystickPagination-icingadb.phtml
@@ -15,20 +15,20 @@ if ($flipUrl->hasParam('page')) {
 if ($flipUrl->hasParam('limit')) {
     $flipUrl->setParam('limit', implode(',', array_reverse(explode(',', $flipUrl->getParam('limit')))));
 }
-$yAxisItemCountPerPage = $yAxisPaginator->getLimit();
+
 $yAxisTotalItem = $yAxisPaginator->count();
+$yAxisItemCountPerPage = $yAxisPaginator->getLimit() ?? $yAxisTotalItem;
 $totalYAxisPages = ceil($yAxisTotalItem / $yAxisItemCountPerPage);
 $currentYAxisPage = round($yAxisPaginator->getOffset() / $yAxisItemCountPerPage) + 1;
 $prevYAxisPage = $currentYAxisPage > 1 ? $currentYAxisPage - 1 : null;
 $nextYAxisPage = $currentYAxisPage < $totalYAxisPages ? $currentYAxisPage + 1 : null;
 
-$xAxisItemCountPerPage = $xAxisPaginator->getLimit();
 $xAxisTotalItem = $xAxisPaginator->count();
+$xAxisItemCountPerPage = $xAxisPaginator->getLimit() ?? $xAxisTotalItem;
 $totalXAxisPages = ceil($xAxisTotalItem / $xAxisItemCountPerPage);
 $currentXAxisPage = round($xAxisPaginator->getOffset() / $xAxisItemCountPerPage) + 1;
 $prevXAxisPage = $currentXAxisPage > 1 ? $currentXAxisPage - 1 : null;
 $nextXAxisPage = $currentXAxisPage < $totalXAxisPages ? $currentXAxisPage + 1 : null;
-
 ?>
 
 <table class="joystick-pagination">

--- a/application/views/scripts/services/grid-flipped.phtml
+++ b/application/views/scripts/services/grid-flipped.phtml
@@ -97,12 +97,13 @@ foreach ($pivotData as $serviceDescription => $_) {
             </td>
         <?php endforeach ?>
         <?php
-        $horizontalItemsPerPage = $this->horizontalPaginator->getLimit();
-        $horizontalTotalPages = ceil($this->horizontalPaginator->count() / $horizontalItemsPerPage);
+        $horizontalTotalItems = $this->horizontalPaginator->count();
+        $horizontalItemsPerPage = $this->horizontalPaginator->getLimit() ?? $horizontalTotalItems;
+        $horizontalTotalPages = ceil($horizontalTotalItems / $horizontalItemsPerPage);
 
-
-        $verticalItemsPerPage = $this->verticalPaginator->getLimit();
-        $verticalTotalPages = ceil($this->verticalPaginator->count() / $verticalItemsPerPage);
+        $verticalTotalItems = $this->verticalPaginator->count();
+        $verticalItemsPerPage = $this->verticalPaginator->getLimit() ?? $verticalTotalItems;
+        $verticalTotalPages = ceil($verticalTotalItems / $verticalItemsPerPage);
 
         if (! $this->compact && $horizontalTotalPages > 1): ?>
             <td>

--- a/application/views/scripts/services/grid.phtml
+++ b/application/views/scripts/services/grid.phtml
@@ -99,12 +99,13 @@ foreach ($pivotData as $hostName => $_) {
             </td>
         <?php endforeach ?>
         <?php
-        $horizontalItemsPerPage = $this->horizontalPaginator->getLimit();
-        $horizontalTotalPages = ceil($this->horizontalPaginator->count() / $horizontalItemsPerPage);
+        $horizontalTotalItems = $this->horizontalPaginator->count();
+        $horizontalItemsPerPage = $this->horizontalPaginator->getLimit() ?? $horizontalTotalItems;
+        $horizontalTotalPages = ceil($horizontalTotalItems / $horizontalItemsPerPage);
 
-
-        $verticalItemsPerPage = $this->verticalPaginator->getLimit();
-        $verticalTotalPages = ceil($this->verticalPaginator->count() / $verticalItemsPerPage);
+        $verticalTotalItems = $this->verticalPaginator->count();
+        $verticalItemsPerPage = $this->verticalPaginator->getLimit() ?? $verticalTotalItems;
+        $verticalTotalPages = ceil($verticalTotalItems / $verticalItemsPerPage);
 
         if (! $this->compact && $horizontalTotalPages > 1): ?>
             <td>

--- a/library/Icingadb/Data/PivotTable.php
+++ b/library/Icingadb/Data/PivotTable.php
@@ -342,9 +342,10 @@ class PivotTable
 
         $query = $this->queryXAxis();
 
-        $query->limit($limit);
-
-        $query->offset($page > 0 ? ($page - 1) * $limit : 0);
+        if ($limit !== 0) {
+            $query->limit($limit);
+            $query->offset($page > 0 ? ($page - 1) * $limit : 0);
+        }
 
         return $query;
     }
@@ -370,10 +371,12 @@ class PivotTable
                 $page = $this->getPaginationParameter('y', 'page', 1);
             }
         }
-
         $query = $this->queryYAxis();
-        $query->limit($limit);
-        $query->offset($page > 0 ? ($page - 1) * $limit : 0);
+
+        if ($limit !== 0) {
+            $query->limit($limit);
+            $query->offset($page > 0 ? ($page - 1) * $limit : 0);
+        }
 
         return $query;
     }


### PR DESCRIPTION
The pagination parameters must be unset when the limit parameter is `0,0` and the service grid for all the hosts and services must be displayed.

fixes #714 