### PR TITLE
Fix/table list

### DIFF
--- a/library/Icingadb/Widget/ItemList/HostgroupListItem.php
+++ b/library/Icingadb/Widget/ItemList/HostgroupListItem.php
@@ -69,7 +69,9 @@ class HostgroupListItem extends BaseTableRowItem
 
     protected function assembleTitle(BaseHtmlElement $title)
     {
-        $title->addHtml(
+        $wrapper = new HtmlElement('div', Attributes::create(['class' => 'wrapper']));
+
+        $wrapper->addHtml(
             $this->getNoSubjectLink()
                 ? new HtmlElement(
                     'span',
@@ -78,7 +80,9 @@ class HostgroupListItem extends BaseTableRowItem
                 )
                 : new Link($this->item->display_name, Links::hostgroup($this->item), ['class' => 'subject']),
             new HtmlElement('br'),
-            Text::create($this->item->name)
+            new HtmlElement('span', null, Text::create($this->item->name))
         );
+
+        $title->add($wrapper);
     }
 }

--- a/public/css/list/item-table.less
+++ b/public/css/list/item-table.less
@@ -121,6 +121,20 @@ table.item-table {
     vertical-align: middle;
     white-space: nowrap;
 
+    .wrapper {
+      display: flex;
+      flex-wrap: wrap;
+      max-width: 100%;
+
+      > * {
+        flex: 1 1 100%;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: 0;
+      }
+    }
+
     &:not(:last-child) {
       padding-right: 1em;
     }
@@ -128,6 +142,10 @@ table.item-table {
     &.title {
       .text-ellipsis();
       width: 100%;
+
+      br {
+        display: none;
+      }
     }
 
     > * {


### PR DESCRIPTION
Here’s a solution to the overflow problem.
UI wise this is the superior solution, event if it uses excess markup. Most users will never see the latter.

Still, what’s not solved is the overflow for the Host/Service Counts, but it should also work.

![Screenshot 2023-05-25 at 17 00 51](https://github.com/Icinga/icingadb-web/assets/6977434/427d076c-4336-44f9-97a9-f945c203c9c0)
