### PR TITLE
Fix/hide footer when empty in detailed list items

### DIFF
--- a/library/Icingadb/Widget/ItemList/HostListItemDetailed.php
+++ b/library/Icingadb/Widget/ItemList/HostListItemDetailed.php
@@ -97,7 +97,12 @@ class HostListItemDetailed extends BaseHostListItem
             }
         }
 
-        $footer->addHtml($statusIcons);
-        $footer->addHtml($performanceData);
+        if (!empty($statusIcons->getContent())) {
+            $footer->addHtml($statusIcons);
+        }
+
+        if (!empty($performanceData->getContent())) {
+            $footer->addHtml($performanceData);
+        }
     }
 }

--- a/library/Icingadb/Widget/ItemList/ServiceListItemDetailed.php
+++ b/library/Icingadb/Widget/ItemList/ServiceListItemDetailed.php
@@ -101,7 +101,12 @@ class ServiceListItemDetailed extends BaseServiceListItem
             }
         }
 
-        $footer->addHtml($statusIcons);
-        $footer->addHtml($performanceData);
+        if (!empty($statusIcons->getContent())) {
+            $footer->addHtml($statusIcons);
+        }
+
+        if (!empty($performanceData->getContent())) {
+            $footer->addHtml($performanceData);
+        }
     }
 }

--- a/public/css/list/list-item.less
+++ b/public/css/list/list-item.less
@@ -58,7 +58,9 @@
   }
 
   footer {
-    padding-top: .5em;
+    :not(:empty) {
+      padding-top: .5em;
+    }
 
     .status-icons {
       color: @text-color-light;
@@ -130,6 +132,8 @@
     }
 
     .performance-data {
+      margin-left: auto;
+
       .inline-pie {
         display: inline-block;
         line-height: 1.5*.857em;


### PR DESCRIPTION
Host and service list items currently have a padding at the bottom, even when there’s not footer contents. This not only looks odd, but it wastes space.

Currently

![Screenshot 2023-05-31 at 11 36 20](https://github.com/Icinga/icingadb-web/assets/6977434/e9e45972-c199-42a3-805e-252eb445582e)

This is how the fixed version looks

![Screenshot 2023-05-31 at 11 38 23](https://github.com/Icinga/icingadb-web/assets/6977434/d9c3d9b2-b4ff-4ea0-a072-5e938f649ebf)
