### PR TITLE
Fix key-value formatting for json and csv result set

### DIFF
--- a/library/Icingadb/Data/CsvResultSet.php
+++ b/library/Icingadb/Data/CsvResultSet.php
@@ -4,6 +4,8 @@
 
 namespace Icinga\Module\Icingadb\Data;
 
+use DateTime;
+use DateTimeZone;
 use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\ResultSet;
@@ -17,7 +19,7 @@ class CsvResultSet extends ResultSet
         return $this->extractKeysAndValues(parent::current());
     }
 
-    protected function formatValue(string $key, ?string $value): ?string
+    protected function formatValue(string $key, $value): ?string
     {
         if (
             $value
@@ -38,6 +40,9 @@ class CsvResultSet extends ResultSet
             return '"' . str_replace('"', '""', $value) . '"';
         } elseif (is_array($value)) {
             return '"' . implode(',', $value) . '"';
+        } elseif ($value instanceof DateTime) {
+            return $value->setTimezone(new DateTimeZone('UTC'))
+                ->format('Y-m-d\TH:i:s.vP');
         } else {
             return $value;
         }

--- a/library/Icingadb/Data/JsonResultSet.php
+++ b/library/Icingadb/Data/JsonResultSet.php
@@ -4,6 +4,8 @@
 
 namespace Icinga\Module\Icingadb\Data;
 
+use DateTime;
+use DateTimeZone;
 use Icinga\Util\Json;
 use ipl\Orm\Model;
 use ipl\Orm\Query;
@@ -18,7 +20,7 @@ class JsonResultSet extends ResultSet
         return $this->createObject(parent::current());
     }
 
-    protected function formatValue(string $key, ?string $value): ?string
+    protected function formatValue(string $key, $value): ?string
     {
         if (
             $value
@@ -31,6 +33,11 @@ class JsonResultSet extends ResultSet
             )
         ) {
             $value = bin2hex($value);
+        }
+
+        if ($value instanceof DateTime) {
+            return $value->setTimezone(new DateTimeZone('UTC'))
+                ->format('Y-m-d\TH:i:s.vP');
         }
 
         return $value;


### PR DESCRIPTION
Remove parameter type for second argument (`$value`) in `CsvResultSet::formatValue` and `JsonResultSet::formatValue`. Also add date time formatting for `$value` parameter in case it is an instance of `DateTime` object.

fixes #782 