### PR TITLE
BaseItemTable: Introduce layout modes

### DIFF
--- a/library/Icingadb/Common/BaseItemTable.php
+++ b/library/Icingadb/Common/BaseItemTable.php
@@ -55,10 +55,22 @@ abstract class BaseItemTable extends BaseHtmlElement
     {
     }
 
+    /**
+     * Get the table layout to use
+     *
+     * @return string
+     */
+    protected function getLayout(): string
+    {
+        return 'table-layout';
+    }
+
     abstract protected function getItemClass(): string;
 
     protected function assemble()
     {
+        $this->addAttributes(['class' => $this->getLayout()]);
+
         $itemClass = $this->getItemClass();
 
         foreach ($this->data as $data) {

--- a/library/Icingadb/Widget/ItemTable/HostgroupTable.php
+++ b/library/Icingadb/Widget/ItemTable/HostgroupTable.php
@@ -19,14 +19,17 @@ class HostgroupTable extends BaseItemTable
         $this->setDetailUrl(Url::fromPath('icingadb/hostgroup'));
     }
 
+    protected function getLayout(): string
+    {
+        return $this->getViewMode() === 'grid'
+            ? 'group-grid'
+            : parent::getLayout();
+    }
+
     protected function getItemClass(): string
     {
-        if ($this->getViewMode() === 'grid') {
-            $this->addAttributes(['class' => 'group-grid']);
-            return HostgroupGridCell::class;
-        }
-
-        $this->addAttributes(['class' => 'table-layout']);
-        return HostgroupTableRow::class;
+        return $this->getViewMode() === 'grid'
+            ? HostgroupGridCell::class
+            : HostgroupTableRow::class;
     }
 }

--- a/library/Icingadb/Widget/ItemTable/ServicegroupTable.php
+++ b/library/Icingadb/Widget/ItemTable/ServicegroupTable.php
@@ -19,14 +19,17 @@ class ServicegroupTable extends BaseItemTable
         $this->setDetailUrl(Url::fromPath('icingadb/servicegroup'));
     }
 
+    protected function getLayout(): string
+    {
+        return $this->getViewMode() === 'grid'
+            ? 'group-grid'
+            : parent::getLayout();
+    }
+
     protected function getItemClass(): string
     {
-        if ($this->getViewMode() === 'grid') {
-            $this->addAttributes(['class' => 'group-grid']);
-            return ServicegroupGridCell::class;
-        }
-
-        $this->addAttributes(['class' => 'table-layout']);
-        return ServicegroupTableRow::class;
+        return $this->getViewMode() === 'grid'
+            ? ServicegroupGridCell::class
+            : ServicegroupTableRow::class;
     }
 }

--- a/public/css/common.less
+++ b/public/css/common.less
@@ -329,11 +329,11 @@ div.show-more {
     &.servicegroup-table {
       --columns: 1;
     }
-  }
 
-  &.user-table, // TODO: make them lists.....
-  &.usergroup-table {
-    --columns: 0;
+    &.user-table, // TODO: make them lists.....
+    &.usergroup-table {
+      --columns: 0;
+    }
   }
 }
 


### PR DESCRIPTION
This elevates the layout `table-layout`, previously introduced exclusively for host and service group
tables, to the standard layout used for item tables.

fixes #814