### PR TITLE
CommandForm: Don't require a submit button and CSRF token for API requests.

### DIFF
--- a/application/forms/Command/CommandForm.php
+++ b/application/forms/Command/CommandForm.php
@@ -7,7 +7,9 @@ namespace Icinga\Module\Icingadb\Forms\Command;
 use ArrayIterator;
 use Exception;
 use Generator;
+use Icinga\Application\Icinga;
 use Icinga\Application\Logger;
+use Icinga\Application\Web;
 use Icinga\Module\Icingadb\Command\IcingaCommand;
 use Icinga\Module\Icingadb\Command\Transport\CommandTransport;
 use Icinga\Module\Icingadb\Common\Auth;
@@ -87,8 +89,14 @@ abstract class CommandForm extends Form
     protected function assemble()
     {
         $this->assembleElements();
-        $this->assembleSubmitButton();
-        $this->addElement($this->createCsrfCounterMeasure(Session::getSession()->getId()));
+
+        /** @var Web $app */
+        $app = Icinga::app();
+        if ($app->getRequest()->isXmlHttpRequest() || ! $app->getRequest()->isApiRequest()) {
+            // TODO: Remove/adjust this condition once a real API exists and is stable (#162)
+            $this->assembleSubmitButton();
+            $this->addElement($this->createCsrfCounterMeasure(Session::getSession()->getId()));
+        }
     }
 
     protected function onSuccess()


### PR DESCRIPTION
This is only a work-around until #162 is implemented.

In case of a success, a redirect (Status 302, Location set) is issued. Not a 200. The trailing error message can be ignored. If the form validation fails, the form HTML is also returned. (including the error messages)

## Examples

The routes used are the same that are used when issuing commands on multiple objects (bulk actions). So the filter that's used in the examples can be any other filter as well.

### Adding a comment
```
curl -H "Accept: application/json" -u icingaadmin:icinga "http://localhost/icingaweb2/icingadb/hosts/add-comment?host.name=docker-master" -F "comment=kaput" -F "expire_time=2023-08-31T20:00:00" -F "expire=y" -v
*   Trying 127.0.0.1:80...
* Connected to localhost (127.0.0.1) port 80 (#0)
* Server auth using Basic with user 'icingaadmin'
> POST /icingaweb2/icingadb/hosts/add-comment?host.name=docker-master HTTP/1.1
> Host: localhost
> Authorization: Basic aWNpbmdhYWRtaW46aWNpbmdh
> User-Agent: curl/7.81.0
> Accept: application/json
> Content-Length: 362
> Content-Type: multipart/form-data; boundary=------------------------d6bc49424d5a7003
> 
* We are completely uploaded and fine
* Mark bundle as not supporting multiuse
< HTTP/1.1 302 Found
< Server: nginx/1.23.4
< Date: Thu, 31 Aug 2023 14:35:08 GMT
< Content-Type: text/html; charset=UTF-8
< Transfer-Encoding: chunked
< Connection: keep-alive
< X-Powered-By: PHP/8.2.3
< X-Xdebug-Profile-Filename: /tmp/cachegrind.out.118.gz
< Location: /icingaweb2/icingadb/hosts/details?host.name=docker-master
< 
<br />
<font size='1'><table class='xdebug-error xe-uncaught-exception' dir='ltr' border='1' cellspacing='0' cellpadding='1'>
<tr><th align='left' bgcolor='#f57900' colspan="5"><span style='background-color: #cc0000; color: #fce94f; font-size: x-large;'>( ! )</span> Fatal error: Uncaught Error: Class "Icinga\Web\Cookie" not found in /icingaweb2/library/Icinga/Web/Session/Php72Session.php on line <i>22</i></th></tr>
<tr><th align='left' bgcolor='#f57900' colspan="5"><span style='background-color: #cc0000; color: #fce94f; font-size: x-large;'>( ! )</span> Error: Class "Icinga\Web\Cookie" not found in /icingaweb2/library/Icinga/Web/Session/Php72Session.php on line <i>22</i></th></tr>
<tr><th align='left' bgcolor='#e9b96e' colspan='5'>Call Stack</th></tr>
<tr><th align='center' bgcolor='#eeeeec'>#</th><th align='left' bgcolor='#eeeeec'>Time</th><th align='left' bgcolor='#eeeeec'>Memory</th><th align='left' bgcolor='#eeeeec'>Function</th><th align='left' bgcolor='#eeeeec'>Location</th></tr>
<tr><td bgcolor='#eeeeec' align='center'>1</td><td bgcolor='#eeeeec' align='center'>0.5035</td><td bgcolor='#eeeeec' align='right'>13275616</td><td bgcolor='#eeeeec'>Icinga\Web\Notification->__destruct(  )</td><td title='/icingaweb2/library/Icinga/Web/Notification.php' bgcolor='#eeeeec'>.../Notification.php<b>:</b>0</td></tr>
<tr><td bgcolor='#eeeeec' align='center'>2</td><td bgcolor='#eeeeec' align='center'>0.5035</td><td bgcolor='#eeeeec' align='right'>13275992</td><td bgcolor='#eeeeec'>Icinga\Web\Session\PhpSession->write(  )</td><td title='/icingaweb2/library/Icinga/Web/Notification.php' bgcolor='#eeeeec'>.../Notification.php<b>:</b>217</td></tr>
<tr><td bgcolor='#eeeeec' align='center'>3</td><td bgcolor='#eeeeec' align='center'>0.5035</td><td bgcolor='#eeeeec' align='right'>13275992</td><td bgcolor='#eeeeec'>Icinga\Web\Session\Php72Session->open(  )</td><td title='/icingaweb2/library/Icinga/Web/Session/PhpSession.php' bgcolor='#eeeeec'>.../PhpSession.php<b>:</b>167</td></tr>
</table></font>
* Connection #0 to host localhost left intact
```

### Scheduling a downtime
```
curl -H "Accept: application/json" -u icingaadmin:icinga "http://localhost/icingaweb2/icingadb/hosts/schedule-downtime?host.name=docker-master" -F "comment=kaput" -F "start=2023-08-31T20:00:00" -F "end=2023-08-31T22:00:00" -F "flexible=y" -F "hours=1" -F "minutes=0" -F "all_services=n" -F "child_options=0" -v
*   Trying 127.0.0.1:80...
* Connected to localhost (127.0.0.1) port 80 (#0)
* Server auth using Basic with user 'icingaadmin'
> POST /icingaweb2/icingadb/hosts/schedule-downtime?host.name=docker-master HTTP/1.1
> Host: localhost
> Authorization: Basic aWNpbmdhYWRtaW46aWNpbmdh
> User-Agent: curl/7.81.0
> Accept: application/json
> Content-Length: 866
> Content-Type: multipart/form-data; boundary=------------------------606e521b2b4c6088
> 
* We are completely uploaded and fine
* Mark bundle as not supporting multiuse
< HTTP/1.1 302 Found
< Server: nginx/1.23.4
< Date: Thu, 31 Aug 2023 14:39:16 GMT
< Content-Type: text/html; charset=UTF-8
< Transfer-Encoding: chunked
< Connection: keep-alive
< X-Powered-By: PHP/8.2.3
< X-Xdebug-Profile-Filename: /tmp/cachegrind.out.118.gz
< Location: /icingaweb2/icingadb/hosts/details?host.name=docker-master
< 
<br />
<font size='1'><table class='xdebug-error xe-uncaught-exception' dir='ltr' border='1' cellspacing='0' cellpadding='1'>
<tr><th align='left' bgcolor='#f57900' colspan="5"><span style='background-color: #cc0000; color: #fce94f; font-size: x-large;'>( ! )</span> Fatal error: Uncaught Error: Class "Icinga\Web\Cookie" not found in /icingaweb2/library/Icinga/Web/Session/Php72Session.php on line <i>22</i></th></tr>
<tr><th align='left' bgcolor='#f57900' colspan="5"><span style='background-color: #cc0000; color: #fce94f; font-size: x-large;'>( ! )</span> Error: Class "Icinga\Web\Cookie" not found in /icingaweb2/library/Icinga/Web/Session/Php72Session.php on line <i>22</i></th></tr>
<tr><th align='left' bgcolor='#e9b96e' colspan='5'>Call Stack</th></tr>
<tr><th align='center' bgcolor='#eeeeec'>#</th><th align='left' bgcolor='#eeeeec'>Time</th><th align='left' bgcolor='#eeeeec'>Memory</th><th align='left' bgcolor='#eeeeec'>Function</th><th align='left' bgcolor='#eeeeec'>Location</th></tr>
<tr><td bgcolor='#eeeeec' align='center'>1</td><td bgcolor='#eeeeec' align='center'>0.5320</td><td bgcolor='#eeeeec' align='right'>13539944</td><td bgcolor='#eeeeec'>Icinga\Web\Notification->__destruct(  )</td><td title='/icingaweb2/library/Icinga/Web/Notification.php' bgcolor='#eeeeec'>.../Notification.php<b>:</b>0</td></tr>
<tr><td bgcolor='#eeeeec' align='center'>2</td><td bgcolor='#eeeeec' align='center'>0.5320</td><td bgcolor='#eeeeec' align='right'>13540320</td><td bgcolor='#eeeeec'>Icinga\Web\Session\PhpSession->write(  )</td><td title='/icingaweb2/library/Icinga/Web/Notification.php' bgcolor='#eeeeec'>.../Notification.php<b>:</b>217</td></tr>
<tr><td bgcolor='#eeeeec' align='center'>3</td><td bgcolor='#eeeeec' align='center'>0.5320</td><td bgcolor='#eeeeec' align='right'>13540320</td><td bgcolor='#eeeeec'>Icinga\Web\Session\Php72Session->open(  )</td><td title='/icingaweb2/library/Icinga/Web/Session/PhpSession.php' bgcolor='#eeeeec'>.../PhpSession.php<b>:</b>167</td></tr>
</table></font>
* Connection #0 to host localhost left intact
```
