### PR TITLE
Add `icingadb/api/v1` endpoint to issue actions for hosts and services

### DIFF
--- a/application/controllers/ApiV1HostsController.php
+++ b/application/controllers/ApiV1HostsController.php
@@ -1,0 +1,33 @@
+<?php
+
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+
+namespace Icinga\Module\Icingadb\Controllers;
+
+use Icinga\Module\Icingadb\Api\V1\ObjectsController;
+use Icinga\Module\Icingadb\Model\Host;
+use Icinga\Module\Icingadb\Redis\VolatileStateResults;
+use ipl\Stdlib\Filter;
+
+class ApiV1HostsController extends ObjectsController
+{
+    protected function fetchCommandTargets()
+    {
+        $db = $this->getDb();
+
+        $hosts = Host::on($db)->with('state');
+        $hosts->setResultSetClass(VolatileStateResults::class);
+
+        switch ($this->getRequest()->getActionName()) {
+            case 'acknowledge':
+                $hosts->filter(Filter::equal('state.is_problem', 'y'))
+                    ->filter(Filter::equal('state.is_acknowledged', 'n'));
+
+                break;
+        }
+
+        $this->filter($hosts);
+
+        return $hosts;
+    }
+}

--- a/application/controllers/ApiV1ServicesController.php
+++ b/application/controllers/ApiV1ServicesController.php
@@ -1,0 +1,38 @@
+<?php
+
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+
+namespace Icinga\Module\Icingadb\Controllers;
+
+use Icinga\Module\Icingadb\Api\V1\ObjectsController;
+use Icinga\Module\Icingadb\Model\Service;
+use Icinga\Module\Icingadb\Redis\VolatileStateResults;
+use ipl\Orm\Query;
+use ipl\Stdlib\Filter;
+
+class ApiV1ServicesController extends ObjectsController
+{
+    protected function fetchCommandTargets(): Query
+    {
+        $db = $this->getDb();
+
+        $services = Service::on($db)->with([
+            'state',
+            'host',
+            'host.state'
+        ]);
+        $services->setResultSetClass(VolatileStateResults::class);
+
+        switch ($this->getRequest()->getActionName()) {
+            case 'acknowledge':
+                $services->filter(Filter::equal('state.is_problem', 'y'))
+                    ->filter(Filter::equal('state.is_acknowledged', 'n'));
+
+                break;
+        }
+
+        $this->filter($services);
+
+        return $services;
+    }
+}

--- a/application/forms/Command/CommandForm.php
+++ b/application/forms/Command/CommandForm.php
@@ -28,6 +28,9 @@ abstract class CommandForm extends Form
     /** @var mixed */
     protected $objects;
 
+    /** @var bool */
+    protected $isApiTarget = false;
+
     /**
      * Whether an error occurred while sending the command
      *
@@ -62,6 +65,30 @@ abstract class CommandForm extends Form
     }
 
     /**
+     * Set whether this form is an API target
+     *
+     * @param bool $state
+     *
+     * @return $this
+     */
+    public function setIsApiTarget(bool $state = true): self
+    {
+        $this->isApiTarget = $state;
+
+        return $this;
+    }
+
+    /**
+     * Get whether this form is an API target
+     *
+     * @return bool
+     */
+    public function isApiTarget(): bool
+    {
+        return $this->isApiTarget;
+    }
+
+    /**
      * Create and add form elements representing the command's options
      *
      * @return void
@@ -87,8 +114,11 @@ abstract class CommandForm extends Form
     protected function assemble()
     {
         $this->assembleElements();
-        $this->assembleSubmitButton();
-        $this->addElement($this->createCsrfCounterMeasure(Session::getSession()->getId()));
+
+        if (! $this->isApiTarget()) {
+            $this->assembleSubmitButton();
+            $this->addElement($this->createCsrfCounterMeasure(Session::getSession()->getId()));
+        }
     }
 
     protected function onSuccess()

--- a/library/Icingadb/Api/V1/ObjectsController.php
+++ b/library/Icingadb/Api/V1/ObjectsController.php
@@ -1,0 +1,66 @@
+<?php
+
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+
+namespace Icinga\Module\Icingadb\Api\V1;
+
+use Icinga\Exception\NotImplementedError;
+use Icinga\Module\Icingadb\Common\CommandActions;
+use Icinga\Module\Icingadb\Forms\Command\CommandForm;
+use Icinga\Module\Icingadb\Web\Controller;
+use Icinga\Web\Notification;
+use ipl\Web\Url;
+
+abstract class ObjectsController extends Controller
+{
+    use CommandActions;
+
+    public function init()
+    {
+        $this->assertHttpMethod('POST');
+
+        if ($this->isXhr()) {
+            $this->httpBadRequest('This endpoint is not accessible from within Icinga Web');
+        }
+
+        if (! $this->getRequest()->isApiRequest()) {
+            $this->httpBadRequest('This endpoint only responds with JSON');
+        }
+
+        parent::init();
+    }
+
+    protected function getCommandTargetsUrl(): Url
+    {
+        throw new NotImplementedError('The API does not issue redirects');
+    }
+
+    protected function handleCommandForm($form)
+    {
+        if (is_string($form)) {
+            /** @var CommandForm $form */
+            $form = new $form();
+        }
+
+        $form->setIsApiTarget();
+        $form->setObjects($this->getCommandTargets());
+        $form->on($form::ON_SUCCESS, function () {
+            $this->getResponse()
+                ->json()
+                ->setSuccessData(Notification::getInstance()->popMessages())
+                ->sendResponse();
+        });
+
+        $form->handleRequest($this->getServerRequest());
+
+        $errors = [];
+        foreach ($form->getElements() as $element) {
+            $errors[$element->getName()] = $element->getMessages();
+        }
+
+        $this->getResponse()
+            ->json()
+            ->setFailData($errors)
+            ->sendResponse();
+    }
+}

--- a/library/Icingadb/Web/Controller/RegexRouter.php
+++ b/library/Icingadb/Web/Controller/RegexRouter.php
@@ -1,0 +1,38 @@
+<?php
+
+/* Icinga DB Web | (c) 2023 Icinga GmbH | GPLv2 */
+
+namespace Icinga\Module\Icingadb\Web\Controller;
+
+use Zend_Controller_Router_Route_Regex;
+
+/**
+ * RegexRouter with support for regex named groups
+ *
+ * This works the same as the standard regex router by Zend.
+ * The only, albeit small, difference is that it supports named regular expression groups.
+ * Allowing to initialize the module, controller and action dynamically.
+ */
+class RegexRouter extends Zend_Controller_Router_Route_Regex
+{
+    public function match($path, $_ = false)
+    {
+        $path = trim(urldecode($path), self::URI_DELIMITER);
+        $pattern = '#^' . $this->_regex . '$#i';
+
+        $res = preg_match($pattern, $path, $values);
+        if (! $res) {
+            return false;
+        }
+
+        // $values are not filtered further here, providing support for named groups
+        unset($values[0]);
+
+        $this->_values = $values;
+
+        $values   = $this->_getMappedValues($values);
+        $defaults = $this->_getMappedValues($this->_defaults, false, true);
+
+        return $values + $defaults;
+    }
+}

--- a/run.php
+++ b/run.php
@@ -2,7 +2,24 @@
 
 /* Icinga DB Web | (c) 2020 Icinga GmbH | GPLv2 */
 
+use Icinga\Module\Icingadb\Web\Controller\RegexRouter;
+
 /** @var $this \Icinga\Application\Modules\Module */
+
+$this->addRoute('api-v1-hosts', new RegexRouter(
+    'icingadb/api/v1/hosts/(?<action>.+)',
+    [
+        'controller' => 'api-v1-hosts',
+        'module' => 'icingadb'
+    ]
+));
+$this->addRoute('api-v1-services', new RegexRouter(
+    'icingadb/api/v1/services/(?<action>.+)',
+    [
+        'controller' => 'api-v1-services',
+        'module' => 'icingadb'
+    ]
+));
 
 $this->provideHook('ApplicationState');
 $this->provideHook('X509/Sni');


### PR DESCRIPTION
This is a first attempt to solve #162.

It still uses the JSON response format provided by Icinga Web and is only accessible for non-XHR clients.

The endpoint for hosts is `icingadb/api/v1/hosts` and for services it is `icingadb/api/v1/services`.

Both accept a filter in the query. Input data must be provided as `multipart/form-data`.

## Examples

The full list of available actions still needs to be documented. Currently the only way to know what's possible is by trial and error.

### Adding a comment
```
curl -H "Accept: application/json" -u icingaadmin:icinga "http://localhost/icingaweb2/icingadb/api/v1/hosts/add-comment?host.name=docker-master" -F "comment=kaput" -F "expire_time=2023-09-05T20:00:00" -F "expire=y" -v
*   Trying 127.0.0.1:80...
* Connected to localhost (127.0.0.1) port 80 (#0)
* Server auth using Basic with user 'icingaadmin'
> POST /icingaweb2/icingadb/api/v1/hosts/add-comment?host.name=docker-master HTTP/1.1
> Host: localhost
> Authorization: Basic aWNpbmdhYWRtaW46aWNpbmdh
> User-Agent: curl/7.81.0
> Accept: application/json
> Content-Length: 362
> Content-Type: multipart/form-data; boundary=------------------------da76739ff7328fd9
> 
* We are completely uploaded and fine
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Server: nginx/1.23.4
< Date: Tue, 05 Sep 2023 07:44:56 GMT
< Content-Type: application/json
< Transfer-Encoding: chunked
< Connection: keep-alive
< X-Powered-By: PHP/8.2.3
< X-Xdebug-Profile-Filename: /tmp/cachegrind.out.128.gz
< 
* Connection #0 to host localhost left intact
{"status":"success","data":[{"type":"success","message":"Added comment successfully"}]}
```

#### In case there's an error

```
curl -H "Accept: application/json" -u icingaadmin:icinga "http://localhost/icingaweb2/icingadb/api/v1/hosts/add-comment?host.name=docker-master" -F "comment=kaput" -F "expire_time=2023-08-05T20:00:00" -F "expire=y" -v
*   Trying 127.0.0.1:80...
* Connected to localhost (127.0.0.1) port 80 (#0)
* Server auth using Basic with user 'icingaadmin'
> POST /icingaweb2/icingadb/api/v1/hosts/add-comment?host.name=docker-master HTTP/1.1
> Host: localhost
> Authorization: Basic aWNpbmdhYWRtaW46aWNpbmdh
> User-Agent: curl/7.81.0
> Accept: application/json
> Content-Length: 362
> Content-Type: multipart/form-data; boundary=------------------------53cd05bc746f90be
> 
* We are completely uploaded and fine
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Server: nginx/1.23.4
< Date: Tue, 05 Sep 2023 07:45:31 GMT
< Content-Type: application/json
< Transfer-Encoding: chunked
< Connection: keep-alive
< X-Powered-By: PHP/8.2.3
< X-Xdebug-Profile-Filename: /tmp/cachegrind.out.129.gz
< 
* Connection #0 to host localhost left intact
{"status":"fail","data":{"comment":[],"expire":[],"expire_time":["The expire time must not be in the past"]}}
```

### Scheduling a downtime
```
curl -H "Accept: application/json" -u icingaadmin:icinga "http://localhost/icingaweb2/icingadb/api/v1/hosts/schedule-downtime?host.name=docker-master" -F "comment=kaput" -F "start=2023-09-05T20:00:00" -F "end=2023-09-05T22:00:00" -F "flexible=y" -F "hours=1" -F "minutes=0" -F "all_services=n" -F "child_options=0" -v
*   Trying 127.0.0.1:80...
* Connected to localhost (127.0.0.1) port 80 (#0)
* Server auth using Basic with user 'icingaadmin'
> POST /icingaweb2/icingadb/api/v1/hosts/schedule-downtime?host.name=docker-master HTTP/1.1
> Host: localhost
> Authorization: Basic aWNpbmdhYWRtaW46aWNpbmdh
> User-Agent: curl/7.81.0
> Accept: application/json
> Content-Length: 866
> Content-Type: multipart/form-data; boundary=------------------------2222dcc7ed0e5442
> 
* We are completely uploaded and fine
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Server: nginx/1.23.4
< Date: Tue, 05 Sep 2023 07:47:10 GMT
< Content-Type: application/json
< Transfer-Encoding: chunked
< Connection: keep-alive
< X-Powered-By: PHP/8.2.3
< X-Xdebug-Profile-Filename: /tmp/cachegrind.out.129.gz
< 
* Connection #0 to host localhost left intact
{"status":"success","data":[{"type":"success","message":"Scheduled downtime successfully"}]}
```