### PR TITLE
Make command actions easier to use with curl

### DIFF
--- a/application/forms/Command/CommandForm.php
+++ b/application/forms/Command/CommandForm.php
@@ -28,6 +28,9 @@ abstract class CommandForm extends Form
     /** @var mixed */
     protected $objects;
 
+    /** @var bool */
+    protected $isApiTarget = false;
+
     /**
      * Whether an error occurred while sending the command
      *
@@ -62,6 +65,30 @@ abstract class CommandForm extends Form
     }
 
     /**
+     * Set whether this form is an API target
+     *
+     * @param bool $state
+     *
+     * @return $this
+     */
+    public function setIsApiTarget(bool $state = true): self
+    {
+        $this->isApiTarget = $state;
+
+        return $this;
+    }
+
+    /**
+     * Get whether this form is an API target
+     *
+     * @return bool
+     */
+    public function isApiTarget(): bool
+    {
+        return $this->isApiTarget;
+    }
+
+    /**
      * Create and add form elements representing the command's options
      *
      * @return void
@@ -87,8 +114,11 @@ abstract class CommandForm extends Form
     protected function assemble()
     {
         $this->assembleElements();
-        $this->assembleSubmitButton();
-        $this->addElement($this->createCsrfCounterMeasure(Session::getSession()->getId()));
+
+        if (! $this->isApiTarget()) {
+            $this->assembleSubmitButton();
+            $this->addElement($this->createCsrfCounterMeasure(Session::getSession()->getId()));
+        }
     }
 
     protected function onSuccess()


### PR DESCRIPTION
The routes used are the same that are used when issuing commands on multiple objects (bulk actions). So the filter that's used in the examples can be any other filter as well. Input data must be provided as `multipart/form-data`.

They respond with the JSON format provided by Icinga Web and are only accessible for non-XHR clients.

## Examples

### Adding a comment
```
curl -H "Accept: application/json" -u icingaadmin:icinga "http://localhost/icingaweb2/icingadb/hosts/add-comment?host.name=docker-master" -F "comment=kaput" -F "expire_time=2023-09-05T20:00:00" -F "expire=y" -v
*   Trying 127.0.0.1:80...
* Connected to localhost (127.0.0.1) port 80 (#0)
* Server auth using Basic with user 'icingaadmin'
> POST /icingaweb2/icingadb/api/v1/hosts/add-comment?host.name=docker-master HTTP/1.1
> Host: localhost
> Authorization: Basic aWNpbmdhYWRtaW46aWNpbmdh
> User-Agent: curl/7.81.0
> Accept: application/json
> Content-Length: 362
> Content-Type: multipart/form-data; boundary=------------------------da76739ff7328fd9
> 
* We are completely uploaded and fine
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Server: nginx/1.23.4
< Date: Tue, 05 Sep 2023 07:44:56 GMT
< Content-Type: application/json
< Transfer-Encoding: chunked
< Connection: keep-alive
< X-Powered-By: PHP/8.2.3
< X-Xdebug-Profile-Filename: /tmp/cachegrind.out.128.gz
< 
* Connection #0 to host localhost left intact
{"status":"success","data":[{"type":"success","message":"Added comment successfully"}]}
```

#### In case there's an error
```
curl -H "Accept: application/json" -u icingaadmin:icinga "http://localhost/icingaweb2/icingadb/hosts/add-comment?host.name=docker-master" -F "comment=kaput" -F "expire_time=2023-08-05T20:00:00" -F "expire=y" -v
*   Trying 127.0.0.1:80...
* Connected to localhost (127.0.0.1) port 80 (#0)
* Server auth using Basic with user 'icingaadmin'
> POST /icingaweb2/icingadb/api/v1/hosts/add-comment?host.name=docker-master HTTP/1.1
> Host: localhost
> Authorization: Basic aWNpbmdhYWRtaW46aWNpbmdh
> User-Agent: curl/7.81.0
> Accept: application/json
> Content-Length: 362
> Content-Type: multipart/form-data; boundary=------------------------53cd05bc746f90be
> 
* We are completely uploaded and fine
* Mark bundle as not supporting multiuse
< HTTP/1.1 422
< Server: nginx/1.23.4
< Date: Tue, 05 Sep 2023 07:45:31 GMT
< Content-Type: application/json
< Transfer-Encoding: chunked
< Connection: keep-alive
< X-Powered-By: PHP/8.2.3
< X-Xdebug-Profile-Filename: /tmp/cachegrind.out.129.gz
< 
* Connection #0 to host localhost left intact
{"status":"fail","data":{"comment":[],"expire":[],"expire_time":["The expire time must not be in the past"]}}
```

### Scheduling a downtime
```
curl -H "Accept: application/json" -u icingaadmin:icinga "http://localhost/icingaweb2/icingadb/hosts/schedule-downtime?host.name=docker-master" -F "comment=kaput" -F "start=2023-09-05T20:00:00" -F "end=2023-09-05T22:00:00" -F "flexible=y" -F "hours=1" -F "minutes=0" -F "all_services=n" -F "child_options=0" -v
*   Trying 127.0.0.1:80...
* Connected to localhost (127.0.0.1) port 80 (#0)
* Server auth using Basic with user 'icingaadmin'
> POST /icingaweb2/icingadb/api/v1/hosts/schedule-downtime?host.name=docker-master HTTP/1.1
> Host: localhost
> Authorization: Basic aWNpbmdhYWRtaW46aWNpbmdh
> User-Agent: curl/7.81.0
> Accept: application/json
> Content-Length: 866
> Content-Type: multipart/form-data; boundary=------------------------2222dcc7ed0e5442
> 
* We are completely uploaded and fine
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Server: nginx/1.23.4
< Date: Tue, 05 Sep 2023 07:47:10 GMT
< Content-Type: application/json
< Transfer-Encoding: chunked
< Connection: keep-alive
< X-Powered-By: PHP/8.2.3
< X-Xdebug-Profile-Filename: /tmp/cachegrind.out.129.gz
< 
* Connection #0 to host localhost left intact
{"status":"success","data":[{"type":"success","message":"Scheduled downtime successfully"}]}
```