### PR TITLE
Add document for the configuration of the IcingaDB-Modul

### DIFF
--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -63,7 +63,12 @@ For this you need an `ApiUser` object with at least the following permissions on
 
 ## General Configuration
 
-Navigate into `Modules` -> `icingadb`.
+There are module options, which change the default behaviour of the dialogs one gets
+when triggering an action (for example the "Acknowledge now" button).
+These options can not be set from the web interface directly but have to be set in the
+configuration file.
+
+The relevant file `config.ini` will in most case recide in `/etc/icingaweb2/modules/icingadb`
 
 ### Available Settings and defaults
 
@@ -87,15 +92,17 @@ servicedowntime_end_fixed         | Sets default value for "End Time" in Schedul
 servicedowntime_end_flexible      | Set default value for "End Time" in Schedule Service Downtime dialog for **Flexible** downtime, its calculated as now + this setting. Format is a [PHP Dateinterval](http://www.php.net/manual/en/dateinterval.construct.php). | **1 hour (PT1H)**.
 servicedowntime_flexible_duration | Set default value for "Flexible Duration" in Schedule Service Downtime dialog for **Flexible** downtime. Format is a [PHP Dateinterval](http://www.php.net/manual/en/dateinterval.construct.php). | **2 hour (PT2H)**.
 
-Example for having acknowledgements with 2 hours expire time by default.
+
+### Example
+
+Setting acknowledgements with 2 hours expire time by default.
+In the `config.ini` file (likely `/etc/icingaweb2/modules/icingadb/config.ini`) the following
+text is entered:
 
 ```
-# vim /etc/icingaweb2/modules/icingadb/config.ini
-
 [settings]
 acknowledge_expire = 1
 acknowledge_expire_time = PT2H
-
 ```
 
 ## Security

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -61,6 +61,43 @@ For this you need an `ApiUser` object with at least the following permissions on
     also configure the secondary master's API command transport.
     Icinga DB Web then uses this transport if the primary one is not available.
 
+## General Configuration
+
+Navigate into `Modules` -> `icingadb`.
+
+### Available Settings and defaults
+
+Option                            | Description                      | Default
+----------------------------------|-----------------------------------|------------
+acknowledge_expire                | Sets "Use Expire Time" in Acknowledgement dialog. | **0 (false)**
+acknowledge_expire_time           | Sets the value for "Expire Time" in Acknowledgement dialog, its calculated as now + this setting. Format is a [PHP Dateinterval](http://www.php.net/manual/en/dateinterval.construct.php). | **1 hour (PT1H)**.
+acknowledge_notify                | Sets "Send Notification" in Acknowledgement dialog. | **1 (true)**
+acknowledge_persistent            | Sets "Persistent Comment" in Acknowledgement dialog. | **0 (false)**
+acknowledge_sticky                | Sets "Sticky Acknowledgement" in Acknowledgement dialog. | **0 (false)**
+comment_expire                    | Sets "Use Expire Time" in Comment dialog. | **0 (false)**
+hostdowntime_comment_text         | Sets default text for "Comment" in Host Downtime dialog | ""
+servicedowntime_comment_text      | Sets default text for "Comment" in Service Downtime dialog. | ""
+comment_expire_time               | Sets default value for "Expire Time" in Comment dialog, its calculated as now + this setting. Format is a [PHP Dateinterval](http://www.php.net/manual/en/dateinterval.construct.php). | **1 hour (PT1H)**
+custom_notification_forced        | Sets "Forced" in Custom Notification dialog. | **0 (false)**
+hostdowntime_all_services         | Sets "All Services" in Schedule Host Downtime dialog. | **0 (false)**
+hostdowntime_end_fixed            | Sets default value for "End Time" in Schedule Host Downtime dialog for **Fixed** downtime, its calculated as now + this setting. Format is a [PHP Dateinterval](http://www.php.net/manual/en/dateinterval.construct.php). | **1 hour (PT1H)**.
+hostdowntime_end_flexible         | Sets default value for "End Time" in Schedule Host Downtime dialog for **Flexible** downtime, its calculated as now + this setting. Format is a [PHP Dateinterval](http://www.php.net/manual/en/dateinterval.construct.php). | **2 hours (PT2H)**.
+hostdowntime_flexible_duration    | Sets default value for "Flexible Duration" in Schedule Host Downtime dialog for **Flexible** downtime. Format is a [PHP Dateinterval](http://www.php.net/manual/en/dateinterval.construct.php). | **2 hour (PT2H)**.
+servicedowntime_end_fixed         | Sets default value for "End Time" in Schedule Service Downtime dialog for **Fixed** downtime, its calculated as now + this setting. Format is a [PHP Dateinterval](http://www.php.net/manual/en/dateinterval.construct.php). | **1 hour (PT1H)**.
+servicedowntime_end_flexible      | Set default value for "End Time" in Schedule Service Downtime dialog for **Flexible** downtime, its calculated as now + this setting. Format is a [PHP Dateinterval](http://www.php.net/manual/en/dateinterval.construct.php). | **1 hour (PT1H)**.
+servicedowntime_flexible_duration | Set default value for "Flexible Duration" in Schedule Service Downtime dialog for **Flexible** downtime. Format is a [PHP Dateinterval](http://www.php.net/manual/en/dateinterval.construct.php). | **2 hour (PT2H)**.
+
+Example for having acknowledgements with 2 hours expire time by default.
+
+```
+# vim /etc/icingaweb2/modules/icingadb/config.ini
+
+[settings]
+acknowledge_expire = 1
+acknowledge_expire_time = PT2H
+
+```
+
 ## Security
 
 To grant users permissions to run commands and restrict them to specific views,

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -93,8 +93,6 @@ servicedowntime_flexible_duration | Set default value for "Flexible Duration" in
 ### Example
 
 Setting acknowledgements with 2 hours expire time by default.
-In the `config.ini` file (likely `/etc/icingaweb2/modules/icingadb/config.ini`) the following
-text is entered:
 
 ```
 [settings]

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -63,8 +63,8 @@ For this you need an `ApiUser` object with at least the following permissions on
 
 ## General Configuration
 
-You can adjust the default values of options users have while interacting with particular dialogs in the UI. (e.g. While acknowledging a problem)
-These options can not be set from the web interface directly but have to be set in the
+Some default values for actions with dialogs in the UI can be adjusted (e.g. While acknowledging a problem).
+These options can not be adjusted in the UI directly, but have to be set in the
 configuration file `/etc/icingaweb2/modules/icingadb/config.ini`.
 
 ### Available Settings and defaults

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -63,7 +63,7 @@ For this you need an `ApiUser` object with at least the following permissions on
 
 ## General Configuration
 
-Some default values for actions with dialogs in the UI can be adjusted (e.g. While acknowledging a problem).
+You can adjust some default values of options users have while interacting with particular dialogs in the UI. (e.g. While acknowledging a problem)
 These options can not be adjusted in the UI directly, but have to be set in the
 configuration file `/etc/icingaweb2/modules/icingadb/config.ini`.
 

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -63,8 +63,7 @@ For this you need an `ApiUser` object with at least the following permissions on
 
 ## General Configuration
 
-There are module options, which change the default behaviour of the dialogs one gets
-when triggering an action (for example the "Acknowledge now" button).
+You can adjust the default values of options users have while interacting with particular dialogs in the UI. (e.g. While acknowledging a problem)
 These options can not be set from the web interface directly but have to be set in the
 configuration file.
 

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -65,9 +65,7 @@ For this you need an `ApiUser` object with at least the following permissions on
 
 You can adjust the default values of options users have while interacting with particular dialogs in the UI. (e.g. While acknowledging a problem)
 These options can not be set from the web interface directly but have to be set in the
-configuration file.
-
-The relevant file `config.ini` will in most case recide in `/etc/icingaweb2/modules/icingadb`
+configuration file `/etc/icingaweb2/modules/icingadb/config.ini`.
 
 ### Available Settings and defaults
 

--- a/doc/10-Migration.md
+++ b/doc/10-Migration.md
@@ -161,10 +161,9 @@ on that: https://icinga.com/blog/2021/04/07/web-access-control-redefined/#icinga
 
 ## General configuration via config.ini
 
-If some of the default options of the monitoring module (for example setting
-acknowledgements to expire by default) were adjusted via the `config.ini` file,
-migrating those options is done by simply copying the configuration file to the Icinga DB Web module.
-In most cases this would be a
+Icinga DB Web still uses the same configuration format for command transports. This means that the file
+`/etc/icingaweb2/modules/monitoring/config.ini` can simply be copied over to
+`/etc/icingaweb2/modules/icingadb/config.ini`:
 
 ```
 cp /etc/icingaweb2/modules/monitoring/config.ini /etc/icingaweb2/modules/icingadb/config.ini

--- a/doc/10-Migration.md
+++ b/doc/10-Migration.md
@@ -8,6 +8,18 @@ If that is the case, this chapter has you covered.
 
 ## Configuration
 
+### General configuration via config.ini
+
+Icinga DB Web still uses the same configuration format as the monitoring module. This means that the file
+`/etc/icingaweb2/modules/monitoring/config.ini` can simply be copied over to
+`/etc/icingaweb2/modules/icingadb/config.ini`:
+
+```
+cp /etc/icingaweb2/modules/monitoring/config.ini /etc/icingaweb2/modules/icingadb/config.ini
+```
+
+The behaviour of those options remains the same.
+
 ### Command Transports
 
 Icinga DB Web still uses the same configuration format for command transports. This means that the file
@@ -159,14 +171,3 @@ It gives you the chance to review the performed changes, before letting them loo
 take in mind, that Icinga DB Web handles permissions and restrictions differently. Our blog provides details
 on that: https://icinga.com/blog/2021/04/07/web-access-control-redefined/#icingadb-permission-linkage
 
-## General configuration via config.ini
-
-Icinga DB Web still uses the same configuration format for command transports. This means that the file
-`/etc/icingaweb2/modules/monitoring/config.ini` can simply be copied over to
-`/etc/icingaweb2/modules/icingadb/config.ini`:
-
-```
-cp /etc/icingaweb2/modules/monitoring/config.ini /etc/icingaweb2/modules/icingadb/config.ini
-```
-
-The behaviour of those options remains the same.

--- a/doc/10-Migration.md
+++ b/doc/10-Migration.md
@@ -158,3 +158,16 @@ general access to the monitoring module, this is not automatically migrated. You
 It gives you the chance to review the performed changes, before letting them loose on your users. Please also
 take in mind, that Icinga DB Web handles permissions and restrictions differently. Our blog provides details
 on that: https://icinga.com/blog/2021/04/07/web-access-control-redefined/#icingadb-permission-linkage
+
+## General configuration via config.ini
+
+If some of the default options of the monitoring module (for example setting
+acknowledgements to expire by default) were adjusted via the `config.ini` file,
+migrating those options is done by simple copying the configuration file to the icingadb module.
+In most cases this would be a
+
+```
+cp /etc/icingaweb2/modules/monitoring/config.ini /etc/icingaweb2/modules/icingadb/config.ini
+```
+
+The behaviour of those options remains the same.

--- a/doc/10-Migration.md
+++ b/doc/10-Migration.md
@@ -163,7 +163,7 @@ on that: https://icinga.com/blog/2021/04/07/web-access-control-redefined/#icinga
 
 If some of the default options of the monitoring module (for example setting
 acknowledgements to expire by default) were adjusted via the `config.ini` file,
-migrating those options is done by simple copying the configuration file to the icingadb module.
+migrating those options is done by simply copying the configuration file to the Icinga DB Web module.
 In most cases this would be a
 
 ```


### PR DESCRIPTION
This adds a listing of the possible settings for the module in the configuration files.
It is quite similar to the monitoring module, but wasn't documented for this one.