### PR TITLE
Fix missing `name_ci` filter during global group search

### DIFF
--- a/library/Icingadb/Model/Hostgroupsummary.php
+++ b/library/Icingadb/Model/Hostgroupsummary.php
@@ -135,7 +135,7 @@ class Hostgroupsummary extends UnionModel
 
     public function getSearchColumns()
     {
-        return ['display_name'];
+        return ['name_ci', 'display_name'];
     }
 
     public function getDefaultSort()

--- a/library/Icingadb/Model/ServicegroupSummary.php
+++ b/library/Icingadb/Model/ServicegroupSummary.php
@@ -113,7 +113,7 @@ class ServicegroupSummary extends UnionModel
 
     public function getSearchColumns()
     {
-        return ['display_name'];
+        return ['name_ci', 'display_name'];
     }
 
     public function getDefaultSort()


### PR DESCRIPTION
fixes #954

this is is a follow-up from #994