### PR TITLE
JsonResultSetUtils: When query offset is null, Use 0 as default

### DIFF
--- a/library/Icingadb/Data/JsonResultSetUtils.php
+++ b/library/Icingadb/Data/JsonResultSetUtils.php
@@ -70,7 +70,7 @@ trait JsonResultSetUtils
         if ($query->hasLimit()) {
             // Custom limits should still apply
             $query->peekAhead(false);
-            $offset = $query->getOffset();
+            $offset = $query->getOffset() ?? 0;
         } else {
             $query->limit(1000);
             $query->peekAhead();


### PR DESCRIPTION
fixes https://github.com/Icinga/icingadb-web/issues/1014