### PR TITLE
Catch `\Throwable` when utilizing hooks

### DIFF
--- a/library/Icingadb/Hook/ActionsHook/ObjectActionsHook.php
+++ b/library/Icingadb/Hook/ActionsHook/ObjectActionsHook.php
@@ -4,7 +4,6 @@
 
 namespace Icinga\Module\Icingadb\Hook\ActionsHook;
 
-use Exception;
 use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 use Icinga\Exception\IcingaException;
@@ -20,6 +19,7 @@ use ipl\Html\HtmlString;
 use ipl\Html\Text;
 use ipl\Orm\Model;
 use ipl\Web\Widget\Link;
+use Throwable;
 
 use function ipl\Stdlib\get_php_type;
 
@@ -72,7 +72,7 @@ abstract class ObjectActionsHook
                         'data-icinga-module' => $moduleName
                     ]), HtmlString::create($renderedLink)));
                 }
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 Logger::error("Failed to load object actions: %s\n%s", $e, $e->getTraceAsString());
                 $list->addHtml(new HtmlElement('li', null, Text::create(IcingaException::describe($e))));
             }

--- a/library/Icingadb/Hook/CustomVarRendererHook.php
+++ b/library/Icingadb/Hook/CustomVarRendererHook.php
@@ -5,11 +5,11 @@
 namespace Icinga\Module\Icingadb\Hook;
 
 use Closure;
-use Exception;
 use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 use Icinga\Module\Icingadb\Hook\Common\HookUtils;
 use ipl\Orm\Model;
+use Throwable;
 
 abstract class CustomVarRendererHook
 {
@@ -68,7 +68,7 @@ abstract class CustomVarRendererHook
                 if ($hook->prefetchForObject($object)) {
                     $hooks[] = $hook;
                 }
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 Logger::error('Failed to load hook %s:', get_class($hook), $e);
             }
         }
@@ -84,7 +84,7 @@ abstract class CustomVarRendererHook
                     $renderedKey = $hook->renderCustomVarKey($key);
                     $renderedValue = $hook->renderCustomVarValue($key, $value);
                     $group = $hook->identifyCustomVarGroup($key);
-                } catch (Exception $e) {
+                } catch (Throwable $e) {
                     Logger::error('Failed to use hook %s:', get_class($hook), $e);
                     continue;
                 }

--- a/library/Icingadb/Hook/ExtensionHook/ObjectDetailExtensionHook.php
+++ b/library/Icingadb/Hook/ExtensionHook/ObjectDetailExtensionHook.php
@@ -4,7 +4,6 @@
 
 namespace Icinga\Module\Icingadb\Hook\ExtensionHook;
 
-use Exception;
 use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 use Icinga\Exception\IcingaException;
@@ -25,6 +24,7 @@ use ipl\Html\HtmlString;
 use ipl\Html\Text;
 use ipl\Html\ValidHtml;
 use ipl\Orm\Model;
+use Throwable;
 
 use function ipl\Stdlib\get_php_type;
 
@@ -110,7 +110,7 @@ abstract class ObjectDetailExtensionHook extends BaseExtensionHook
                     ]),
                     HtmlString::create($extension)
                 );
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 Logger::error("Failed to load detail extension: %s\n%s", $e, $e->getTraceAsString());
                 $extensions[$location] = Text::create(IcingaException::describe($e));
             }

--- a/library/Icingadb/Hook/ExtensionHook/ObjectsDetailExtensionHook.php
+++ b/library/Icingadb/Hook/ExtensionHook/ObjectsDetailExtensionHook.php
@@ -4,7 +4,6 @@
 
 namespace Icinga\Module\Icingadb\Hook\ExtensionHook;
 
-use Exception;
 use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 use Icinga\Exception\IcingaException;
@@ -19,6 +18,7 @@ use ipl\Html\ValidHtml;
 use ipl\Orm\Query;
 use ipl\Stdlib\BaseFilter;
 use ipl\Stdlib\Filter;
+use Throwable;
 
 abstract class ObjectsDetailExtensionHook extends BaseExtensionHook
 {
@@ -90,7 +90,7 @@ abstract class ObjectsDetailExtensionHook extends BaseExtensionHook
                     ]),
                     HtmlString::create($extension)
                 );
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 Logger::error("Failed to load details extension: %s\n%s", $e, $e->getTraceAsString());
                 $extensions[$location] = Text::create(IcingaException::describe($e));
             }

--- a/library/Icingadb/Hook/PluginOutputHook.php
+++ b/library/Icingadb/Hook/PluginOutputHook.php
@@ -4,10 +4,10 @@
 
 namespace Icinga\Module\Icingadb\Hook;
 
-use Exception;
 use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 use Icinga\Module\Icingadb\Hook\Common\HookUtils;
+use Throwable;
 
 abstract class PluginOutputHook
 {
@@ -53,7 +53,7 @@ abstract class PluginOutputHook
                 if ($hook->isSupportedCommand($commandName)) {
                     $output = $hook->render($output, $commandName, $enrichOutput);
                 }
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 Logger::error("Unable to process plugin output: %s\n%s", $e, $e->getTraceAsString());
             }
         }

--- a/library/Icingadb/Hook/TabHook/HookActions.php
+++ b/library/Icingadb/Hook/TabHook/HookActions.php
@@ -4,7 +4,6 @@
 
 namespace Icinga\Module\Icingadb\Hook\TabHook;
 
-use Exception;
 use Generator;
 use Icinga\Application\Hook;
 use Icinga\Application\Logger;
@@ -12,6 +11,7 @@ use Icinga\Module\Icingadb\Hook\TabHook;
 use ipl\Html\ValidHtml;
 use ipl\Orm\Model;
 use ipl\Stdlib\Str;
+use Throwable;
 
 /**
  * Trait HookActions
@@ -78,7 +78,7 @@ trait HookActions
                 if ($hook->shouldBeShown($this->objectToLoadTabsFor)) {
                     $this->tabHooks[Str::camel($hook->getName())] = $hook;
                 }
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 Logger::error("Failed to load tab hook: %s\n%s", $e, $e->getTraceAsString());
             }
         }

--- a/library/Icingadb/Widget/Detail/ObjectDetail.php
+++ b/library/Icingadb/Widget/Detail/ObjectDetail.php
@@ -4,7 +4,6 @@
 
 namespace Icinga\Module\Icingadb\Widget\Detail;
 
-use Exception;
 use Icinga\Application\ClassLoader;
 use Icinga\Application\Hook;
 use Icinga\Application\Hook\GrapherHook;
@@ -52,6 +51,7 @@ use ipl\Orm\ResultSet;
 use ipl\Stdlib\Filter;
 use ipl\Web\Widget\Icon;
 use ipl\Web\Widget\StateBall;
+use Throwable;
 
 class ObjectDetail extends BaseHtmlElement
 {
@@ -169,7 +169,7 @@ class ObjectDetail extends BaseHtmlElement
                 if (! isset($nativeExtensionProviders[$moduleName])) {
                     try {
                         $navigation->merge($hook->getNavigation($this->compatObject()));
-                    } catch (Exception $e) {
+                    } catch (Throwable $e) {
                         Logger::error("Failed to load legacy action hook: %s\n%s", $e, $e->getTraceAsString());
                         $navigation->addItem($moduleName, ['label' => IcingaException::describe($e), 'url' => '#']);
                     }
@@ -469,7 +469,7 @@ class ObjectDetail extends BaseHtmlElement
 
             try {
                 $graph = HtmlString::create($grapher->getPreviewHtml($this->compatObject()));
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 Logger::error("Failed to load legacy grapher: %s\n%s", $e, $e->getTraceAsString());
                 $graph = Text::create(IcingaException::describe($e));
             }
@@ -505,7 +505,7 @@ class ObjectDetail extends BaseHtmlElement
                     ]),
                     HtmlString::create($renderedExtension)
                 );
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 Logger::error("Failed to load legacy detail extension: %s\n%s", $e, $e->getTraceAsString());
                 $extensionHtml = Text::create(IcingaException::describe($e));
             }


### PR DESCRIPTION
Hooks shouldn't be able to fatally end execution.