### PR TITLE
Fix unstable service order

### DIFF
--- a/application/controllers/ServicegroupController.php
+++ b/application/controllers/ServicegroupController.php
@@ -78,11 +78,11 @@ class ServicegroupController extends Controller
         $sortControl = $this->createSortControl(
             $services,
             [
-                'service.display_name'                                             => t('Name'),
-                'service.state.severity desc,service.state.last_state_change desc' => t('Severity'),
-                'service.state.soft_state'                                         => t('Current State'),
-                'service.state.last_state_change desc'                             => t('Last State Change'),
-                'host.display_name'                                                => t('Host')
+                'service.display_name, host.display_name'                           => t('Name'),
+                'service.state.severity desc,service.state.last_state_change desc'  => t('Severity'),
+                'service.state.soft_state, service.display_name, host.display_name' => t('Current State'),
+                'service.state.last_state_change desc'                              => t('Last State Change'),
+                'host.display_name, service.display_name'                           => t('Host')
             ]
         );
         $viewModeSwitcher = $this->createViewModeSwitcher($paginationControl, $limitControl);

--- a/application/controllers/ServicesController.php
+++ b/application/controllers/ServicesController.php
@@ -63,11 +63,11 @@ class ServicesController extends Controller
         $sortControl = $this->createSortControl(
             $services,
             [
-                'service.display_name'                                             => t('Name'),
-                'service.state.severity desc,service.state.last_state_change desc' => t('Severity'),
-                'service.state.soft_state'                                         => t('Current State'),
-                'service.state.last_state_change desc'                             => t('Last State Change'),
-                'host.display_name'                                                => t('Host')
+                'service.display_name, host.display_name'                           => t('Name'),
+                'service.state.severity desc,service.state.last_state_change desc'  => t('Severity'),
+                'service.state.soft_state, service.display_name, host.display_name' => t('Current State'),
+                'service.state.last_state_change desc'                              => t('Last State Change'),
+                'host.display_name, service.display_name'                           => t('Host')
             ]
         );
         $viewModeSwitcher = $this->createViewModeSwitcher($paginationControl, $limitControl);


### PR DESCRIPTION
Services usually have similar (if not equal) names across different hosts. Sorting such after (display_)name, might result in unexpected results depending on the used database backend.

To guarantee a deterministic order we have to use more than a single column if said column isn't variant enough.