### PR TITLE
db: Cleanup parent/child relations in matching models

### DIFF
--- a/library/Icingadb/Model/DependencyEdge.php
+++ b/library/Icingadb/Model/DependencyEdge.php
@@ -17,8 +17,8 @@ use ipl\Orm\Relations;
  * @property string $from_node_id
  * @property ?string $dependency_id
  *
- * @property DependencyNode|Query $from
- * @property DependencyNode|Query $to
+ * @property DependencyNode|Query $child
+ * @property DependencyNode|Query $parent
  * @property (?Dependency)|Query $dependency
  */
 class DependencyEdge extends Model
@@ -53,11 +53,17 @@ class DependencyEdge extends Model
 
     public function createRelations(Relations $relations): void
     {
+        $relations->belongsTo('child', DependencyNode::class)
+            ->setCandidateKey('from_node_id');
+        $relations->belongsTo('parent', DependencyNode::class)
+            ->setCandidateKey('to_node_id');
+        $relations->belongsTo('dependency', Dependency::class)
+            ->setJoinType('LEFT');
+
+        // "from" and "to" are only necessary for sub-query filters.
         $relations->belongsTo('from', DependencyNode::class)
             ->setCandidateKey('from_node_id');
         $relations->belongsTo('to', DependencyNode::class)
             ->setCandidateKey('to_node_id');
-        $relations->belongsTo('dependency', Dependency::class)
-            ->setJoinType('LEFT');
     }
 }

--- a/library/Icingadb/Model/Host.php
+++ b/library/Icingadb/Model/Host.php
@@ -181,8 +181,8 @@ class Host extends Model
         ]));
 
         $behaviors->add(new ReRoute([
-            'child'         => 'dependency_node.child',
-            'parent'        => 'dependency_node.parent',
+            'child'         => 'to.from',
+            'parent'        => 'from.to',
             'servicegroup'  => 'service.servicegroup',
             'user'          => 'notification.user',
             'usergroup'     => 'notification.usergroup'
@@ -237,8 +237,6 @@ class Host extends Model
 
     public function createRelations(Relations $relations)
     {
-        $relations->belongsTo('dependency_node', DependencyNode::class)
-            ->setJoinType('LEFT');
         $relations->belongsTo('environment', Environment::class);
         $relations->belongsTo('eventcommand', Eventcommand::class);
         $relations->belongsTo('checkcommand', Checkcommand::class);
@@ -274,5 +272,14 @@ class Host extends Model
         $relations->hasMany('notification', Notification::class)->setJoinType('LEFT');
         $relations->hasMany('notification_history', NotificationHistory::class);
         $relations->hasMany('service', Service::class)->setJoinType('LEFT');
+
+        $relations->belongsToMany('from', DependencyEdge::class)
+            ->setTargetCandidateKey('from_node_id')
+            ->setTargetForeignKey('id')
+            ->through(DependencyNode::class);
+        $relations->belongsToMany('to', DependencyEdge::class)
+            ->setTargetCandidateKey('to_node_id')
+            ->setTargetForeignKey('id')
+            ->through(DependencyNode::class);
     }
 }

--- a/library/Icingadb/Model/RedundancyGroup.php
+++ b/library/Icingadb/Model/RedundancyGroup.php
@@ -21,6 +21,8 @@ use ipl\Orm\Relations;
  *
  * @property (?RedundancyGroupState)|Query $state
  * @property Dependency|Query $dependency
+ * @property DependencyEdge|Query $from
+ * @property DependencyEdge|Query $to
  */
 class RedundancyGroup extends Model
 {
@@ -48,20 +50,25 @@ class RedundancyGroup extends Model
             'id'
         ]));
         $behaviors->add(new ReRoute([
-            'child' => 'dependency_node.child',
-            'parent' => 'dependency_node.parent'
+            'child' => 'to.from',
+            'parent' => 'from.to'
         ]));
     }
 
     public function createRelations(Relations $relations): void
     {
-        $relations->belongsTo('dependency_node', DependencyNode::class)
-            ->setForeignKey('redundancy_group_id')
-            ->setCandidateKey('id');
-
         $relations->hasOne('state', RedundancyGroupState::class)
             ->setJoinType('LEFT');
 
         $relations->hasMany('dependency', Dependency::class);
+
+        $relations->belongsToMany('from', DependencyEdge::class)
+            ->setTargetCandidateKey('from_node_id')
+            ->setTargetForeignKey('id')
+            ->through(DependencyNode::class);
+        $relations->belongsToMany('to', DependencyEdge::class)
+            ->setTargetCandidateKey('to_node_id')
+            ->setTargetForeignKey('id')
+            ->through(DependencyNode::class);
     }
 }

--- a/library/Icingadb/Model/Service.php
+++ b/library/Icingadb/Model/Service.php
@@ -170,8 +170,8 @@ class Service extends Model
         ]));
 
         $behaviors->add(new ReRoute([
-            'child'         => 'dependency_node.child',
-            'parent'        => 'dependency_node.parent',
+            'child'         => 'to.from',
+            'parent'        => 'from.to',
             'user'          => 'notification.user',
             'usergroup'     => 'notification.usergroup'
         ]));
@@ -224,8 +224,6 @@ class Service extends Model
 
     public function createRelations(Relations $relations)
     {
-        $relations->belongsTo('dependency_node', DependencyNode::class)
-            ->setJoinType('LEFT');
         $relations->belongsTo('environment', Environment::class);
         $relations->belongsTo('host', Host::class)->setJoinType('LEFT');
         $relations->belongsTo('checkcommand', Checkcommand::class);
@@ -263,5 +261,14 @@ class Service extends Model
         $relations->hasMany('history', History::class);
         $relations->hasMany('notification', Notification::class)->setJoinType('LEFT');
         $relations->hasMany('notification_history', NotificationHistory::class);
+
+        $relations->belongsToMany('from', DependencyEdge::class)
+            ->setTargetCandidateKey('from_node_id')
+            ->setTargetForeignKey('id')
+            ->through(DependencyNode::class);
+        $relations->belongsToMany('to', DependencyEdge::class)
+            ->setTargetCandidateKey('to_node_id')
+            ->setTargetForeignKey('id')
+            ->through(DependencyNode::class);
     }
 }


### PR DESCRIPTION
The previous relations didn't work as expected.
Now, filtering with `child.host.name` or
`parent.service.name` works fine.