### PR TITLE
ObjectSuggestions: Make CustomVar suggestion sources adjustable

### DIFF
--- a/application/controllers/RedundancygroupController.php
+++ b/application/controllers/RedundancygroupController.php
@@ -230,6 +230,7 @@ class RedundancygroupController extends Controller
         $suggestions = (new ObjectSuggestions())
             ->setModel(DependencyNode::class)
             ->setBaseFilter(Filter::equal("$column.redundancy_group.id", $this->groupId))
+            ->onlyWithCustomVarSources(['host', 'service', 'hostgroup', 'servicegroup'])
             ->forRequest($this->getServerRequest());
 
         $this->getDocument()->add($suggestions);

--- a/library/Icingadb/Model/Hostgroup.php
+++ b/library/Icingadb/Model/Hostgroup.php
@@ -71,7 +71,9 @@ class Hostgroup extends Model
     public function createBehaviors(Behaviors $behaviors)
     {
         $behaviors->add(new ReRoute([
-            'servicegroup'  => 'service.servicegroup'
+            'servicegroup'  => 'service.servicegroup',
+            'parent'        => 'host.from.to',
+            'child'         => 'host.to.from'
         ]));
 
         $behaviors->add(new Binary([

--- a/library/Icingadb/Model/Servicegroup.php
+++ b/library/Icingadb/Model/Servicegroup.php
@@ -72,7 +72,9 @@ class Servicegroup extends Model
     {
         $behaviors->add(new ReRoute([
             'host'      => 'service.host',
-            'hostgroup' => 'service.hostgroup'
+            'hostgroup' => 'service.hostgroup',
+            'parent'    => 'service.from.to',
+            'child'     => 'service.to.from'
         ]));
 
         $behaviors->add(new Binary([

--- a/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
+++ b/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
@@ -419,4 +419,18 @@ class ObjectSuggestions extends Suggestions
             }
         }
     }
+
+    /**
+     * Reduce {@see $customVarSources} to only given relations to fetch variables from
+     *
+     * @param string[] $relations
+     *
+     * @return $this
+     */
+    public function onlyWithCustomVarSources(array $relations): self
+    {
+        $this->customVarSources = array_intersect_key($this->customVarSources, array_flip($relations));
+
+        return $this;
+    }
 }


### PR DESCRIPTION
The `ObjectSuggestions` instance with `DependencyNode` as the model can only retrieve custom variables for `Host, Service, Hostgroup and Servicegroup`. Other relations are not defined and lead to an error.