### PR TITLE
ObjectSuggestions: Don't apply base filter to $customVars query

### DIFF
--- a/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
+++ b/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
@@ -301,7 +301,7 @@ class ObjectSuggestions extends Suggestions
         }
 
         $customVars->columns('flatname');
-        $this->applyBaseFilter($customVars);
+        $this->applyRestrictions($customVars);
         $customVars->filter(Filter::like('flatname', $searchTerm));
         $idColumn = $resolver->qualifyColumn('id', $resolver->getAlias($customVars->getModel()));
         $customVars = $customVars->assembleSelect();


### PR DESCRIPTION
Blocked by: https://github.com/Icinga/icingadb-web/pull/1100

 - The basefilter may contain relations, that are not know to `CustomvarFlat`, which can leads to errors. 
      For example: `RedundancygroupController:completeAction`'s base filter (`(parent|child).redundancy_group.id)`) is not known to `CustomvarFlat`.