### PR TITLE
ObjectSuggestions: Fix exotic columns match

### DIFF
--- a/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
+++ b/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
@@ -260,10 +260,9 @@ class ObjectSuggestions extends Suggestions
 
     protected function matchSuggestion($path, $label, $searchTerm)
     {
-        if (preg_match('/[_.](id|bin|checksum)$/', $path)) {
-            // Only suggest exotic columns if the user knows about them
-            $trimmedSearch = trim($searchTerm, ' *');
-            return substr($path, -strlen($trimmedSearch)) === $trimmedSearch;
+        if (preg_match('/[_.](id|bin|checksum)$/', $path, $matches)) {
+            // Only suggest exotic columns if the user knows the full column path
+            return substr($path, strrpos($path, '.') + 1) === trim($searchTerm, ' *');
         }
 
         return parent::matchSuggestion($path, $label, $searchTerm);


### PR DESCRIPTION
These columns should only be displayed if the full column name is explicitly specified by the user.
   For example: `name_checksum` should show matches, but (`name|checksum|_checksum|ame_checksum`) should not.
Previously, exotic columns were also suggested, even if only the column name suffix matched