### PR TITLE
Use singleton for db and redis connections

### DIFF
--- a/doc/05-Upgrading.md
+++ b/doc/05-Upgrading.md
@@ -12,6 +12,9 @@ The following classes have been deprecated and will be removed in a future relea
 * `\Icinga\Module\Icingadb\Command\Object\ScheduleHostDowntimeCommand`
 * `\Icinga\Module\Icingadb\Command\Object\ScheduleServiceDowntimeCommand`
 
+The following methods have been deprecated and will be removed in a future release:
+* `\Icinga\Module\Icingadb\Common\IcingaRedis::instance()`: Use `\Icinga\Module\Icingadb\Common\Backend::getRedis()` instead.
+
 ## Upgrading to Icinga DB Web v1.1
 
 **Breaking Changes**

--- a/library/Icingadb/Common/Backend.php
+++ b/library/Icingadb/Common/Backend.php
@@ -1,0 +1,168 @@
+<?php
+
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+
+namespace Icinga\Module\Icingadb\Common;
+
+use Icinga\Application\Config as AppConfig;
+use Icinga\Data\ResourceFactory;
+use Icinga\Module\Icingadb\Model\Schema;
+use ipl\Sql\Adapter\Pgsql;
+use ipl\Sql\Config as SqlConfig;
+use ipl\Sql\Connection;
+use ipl\Sql\Expression;
+use ipl\Sql\QueryBuilder;
+use ipl\Sql\Select;
+use PDO;
+
+/**
+ * Singleton providing access to the Icinga DB and Redis
+ */
+final class Backend
+{
+    /** @var ?Connection */
+    private static $db;
+
+    /** @var ?int */
+    private static $schemaVersion;
+
+    /** @var ?IcingaRedis */
+    private static $redis;
+
+    /**
+     * Set the connection to the Icinga DB
+     *
+     * Usually not required, as the connection is created on demand. Useful for testing.
+     *
+     * @param Connection $db
+     *
+     * @return void
+     */
+    public static function setDb(Connection $db): void
+    {
+        self::$db = $db;
+    }
+
+    /**
+     * Get the connection to the Icinga DB
+     *
+     * @return Connection
+     */
+    public static function getDb(): Connection
+    {
+        if (self::$db === null) {
+            $config = new SqlConfig(ResourceFactory::getResourceConfig(
+                AppConfig::module('icingadb')->get('icingadb', 'resource')
+            ));
+
+            $config->options = [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_OBJ];
+            if ($config->db === 'mysql') {
+                $config->options[PDO::MYSQL_ATTR_INIT_COMMAND] = "SET SESSION SQL_MODE='STRICT_TRANS_TABLES"
+                    . ",NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
+            }
+
+            self::$db = new Connection($config);
+
+            $adapter = self::$db->getAdapter();
+            if ($adapter instanceof Pgsql) {
+                $quoted = $adapter->quoteIdentifier('user');
+                self::$db->getQueryBuilder()
+                    ->on(QueryBuilder::ON_SELECT_ASSEMBLED, function (&$sql) use ($quoted) {
+                        // user is a reserved key word in PostgreSQL, so we need to quote it.
+                        // TODO(lippserd): This is pretty hacky,
+                        // reconsider how to properly implement identifier quoting.
+                        $sql = str_replace(' user ', sprintf(' %s ', $quoted), $sql);
+                        $sql = str_replace(' user.', sprintf(' %s.', $quoted), $sql);
+                        $sql = str_replace('(user.', sprintf('(%s.', $quoted), $sql);
+                    })
+                    ->on(QueryBuilder::ON_ASSEMBLE_SELECT, function (Select $select) {
+                        // For SELECT DISTINCT, all ORDER BY columns must appear in SELECT list.
+                        if (! $select->getDistinct() || ! $select->hasOrderBy()) {
+                            return;
+                        }
+
+                        $candidates = [];
+                        foreach ($select->getOrderBy() as list($columnOrAlias, $_)) {
+                            if ($columnOrAlias instanceof Expression) {
+                                // Expressions can be and include anything,
+                                // also columns that aren't already part of the SELECT list,
+                                // so we're not trying to guess anything here.
+                                // Such expressions must be in the SELECT list if necessary and
+                                // referenced manually with an alias in ORDER BY.
+                                continue;
+                            }
+
+                            $candidates[$columnOrAlias] = true;
+                        }
+
+                        foreach ($select->getColumns() as $alias => $column) {
+                            if (is_int($alias)) {
+                                if ($column instanceof Expression) {
+                                    // This is the complement to the above consideration.
+                                    // If it is an unaliased expression, ignore it.
+                                    continue;
+                                }
+                            } else {
+                                unset($candidates[$alias]);
+                            }
+
+                            if (! $column instanceof Expression) {
+                                unset($candidates[$column]);
+                            }
+                        }
+
+                        if (! empty($candidates)) {
+                            $select->columns(array_keys($candidates));
+                        }
+                    });
+            }
+        }
+
+        return self::$db;
+    }
+
+    /**
+     * Get the schema version of the Icinga DB
+     *
+     * @return int
+     */
+    public static function getDbSchemaVersion(): int
+    {
+        if (self::$schemaVersion === null) {
+            self::$schemaVersion = Schema::on(self::getDb())
+                ->columns('version')
+                ->first()
+                ->version ?? 0;
+        }
+
+        return self::$schemaVersion;
+    }
+
+    /**
+     * Set the connection to the Icinga Redis
+     *
+     * Usually not required, as the connection is created on demand. Useful for testing.
+     *
+     * @param IcingaRedis $redis
+     *
+     * @return void
+     */
+    public static function setRedis(IcingaRedis $redis): void
+    {
+        self::$redis = $redis;
+    }
+
+    /**
+     * Get the connection to the Icinga Redis
+     *
+     * @return IcingaRedis
+     */
+    public static function getRedis(): IcingaRedis
+    {
+        if (self::$redis === null) {
+            self::$redis = new IcingaRedis();
+        }
+
+        return self::$redis;
+    }
+}

--- a/library/Icingadb/Common/Database.php
+++ b/library/Icingadb/Common/Database.php
@@ -4,99 +4,17 @@
 
 namespace Icinga\Module\Icingadb\Common;
 
-use Icinga\Application\Config as AppConfig;
-use Icinga\Data\ResourceFactory;
-use Icinga\Exception\ConfigurationError;
-use ipl\Sql\Adapter\Pgsql;
-use ipl\Sql\Config as SqlConfig;
 use ipl\Sql\Connection;
-use ipl\Sql\Expression;
-use ipl\Sql\QueryBuilder;
-use ipl\Sql\Select;
-use PDO;
 
 trait Database
 {
-    /** @var Connection Connection to the Icinga database */
-    private $db;
-
     /**
      * Get the connection to the Icinga database
      *
      * @return Connection
-     *
-     * @throws ConfigurationError If the related resource configuration does not exist
      */
     public function getDb(): Connection
     {
-        if ($this->db === null) {
-            $config = new SqlConfig(ResourceFactory::getResourceConfig(
-                AppConfig::module('icingadb')->get('icingadb', 'resource')
-            ));
-
-            $config->options = [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_OBJ];
-            if ($config->db === 'mysql') {
-                $config->options[PDO::MYSQL_ATTR_INIT_COMMAND] = "SET SESSION SQL_MODE='STRICT_TRANS_TABLES"
-                    . ",NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
-            }
-
-            $this->db = new Connection($config);
-
-            $adapter = $this->db->getAdapter();
-            if ($adapter instanceof Pgsql) {
-                $quoted = $adapter->quoteIdentifier('user');
-                $this->db->getQueryBuilder()
-                    ->on(QueryBuilder::ON_SELECT_ASSEMBLED, function (&$sql) use ($quoted) {
-                        // user is a reserved key word in PostgreSQL, so we need to quote it.
-                        // TODO(lippserd): This is pretty hacky,
-                        // reconsider how to properly implement identifier quoting.
-                        $sql = str_replace(' user ', sprintf(' %s ', $quoted), $sql);
-                        $sql = str_replace(' user.', sprintf(' %s.', $quoted), $sql);
-                        $sql = str_replace('(user.', sprintf('(%s.', $quoted), $sql);
-                    })
-                    ->on(QueryBuilder::ON_ASSEMBLE_SELECT, function (Select $select) {
-                        // For SELECT DISTINCT, all ORDER BY columns must appear in SELECT list.
-                        if (! $select->getDistinct() || ! $select->hasOrderBy()) {
-                            return;
-                        }
-
-                        $candidates = [];
-                        foreach ($select->getOrderBy() as list($columnOrAlias, $_)) {
-                            if ($columnOrAlias instanceof Expression) {
-                                // Expressions can be and include anything,
-                                // also columns that aren't already part of the SELECT list,
-                                // so we're not trying to guess anything here.
-                                // Such expressions must be in the SELECT list if necessary and
-                                // referenced manually with an alias in ORDER BY.
-                                continue;
-                            }
-
-                            $candidates[$columnOrAlias] = true;
-                        }
-
-                        foreach ($select->getColumns() as $alias => $column) {
-                            if (is_int($alias)) {
-                                if ($column instanceof Expression) {
-                                    // This is the complement to the above consideration.
-                                    // If it is an unaliased expression, ignore it.
-                                    continue;
-                                }
-                            } else {
-                                unset($candidates[$alias]);
-                            }
-
-                            if (! $column instanceof Expression) {
-                                unset($candidates[$column]);
-                            }
-                        }
-
-                        if (! empty($candidates)) {
-                            $select->columns(array_keys($candidates));
-                        }
-                    });
-            }
-        }
-
-        return $this->db;
+        return Backend::getDb();
     }
 }

--- a/library/Icingadb/Common/ObjectInspectionDetail.php
+++ b/library/Icingadb/Common/ObjectInspectionDetail.php
@@ -120,7 +120,7 @@ abstract class ObjectInspectionDetail extends BaseHtmlElement
         $title = new HtmlElement('h2', null, Text::create(t('Volatile State Details')));
 
         try {
-            $json = IcingaRedis::instance()->getConnection()
+            $json = Backend::getRedis()->getConnection()
                 ->hGet("icinga:{$this->object->getTableName()}:state", bin2hex($this->object->id));
         } catch (Exception $e) {
             return [$title, sprintf('Failed to load redis data: %s', $e->getMessage())];

--- a/library/Icingadb/Model/Schema.php
+++ b/library/Icingadb/Model/Schema.php
@@ -1,0 +1,50 @@
+<?php
+
+/* Icinga DB Web | (c) 2024 Icinga GmbH | GPLv2 */
+
+namespace Icinga\Module\Icingadb\Model;
+
+use DateTime;
+use ipl\Orm\Behavior\Binary;
+use ipl\Orm\Behavior\MillisecondTimestamp;
+use ipl\Orm\Behaviors;
+use ipl\Orm\Model;
+
+/**
+ * Schema model
+ *
+ * @property string $id
+ * @property int $version
+ * @property DateTime $timestamp
+ */
+class Schema extends Model
+{
+    public function getTableName(): string
+    {
+        return 'icingadb_schema';
+    }
+
+    public function getKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function getColumns(): array
+    {
+        return [
+            'version',
+            'timestamp'
+        ];
+    }
+
+    public function getDefaultSort(): array
+    {
+        return ['timestamp desc'];
+    }
+
+    public function createBehaviors(Behaviors $behaviors): void
+    {
+        $behaviors->add(new Binary(['id']));
+        $behaviors->add(new MillisecondTimestamp(['timestamp']));
+    }
+}

--- a/library/Icingadb/Redis/VolatileStateResults.php
+++ b/library/Icingadb/Redis/VolatileStateResults.php
@@ -6,6 +6,7 @@ namespace Icinga\Module\Icingadb\Redis;
 
 use Icinga\Application\Benchmark;
 use Icinga\Module\Icingadb\Common\Auth;
+use Icinga\Module\Icingadb\Common\Backend;
 use Icinga\Module\Icingadb\Common\IcingaRedis;
 use Icinga\Module\Icingadb\Model\DependencyNode;
 use Icinga\Module\Icingadb\Model\Host;
@@ -39,7 +40,7 @@ class VolatileStateResults extends ResultSet
     {
         $self = parent::fromQuery($query);
         $self->resolver = $query->getResolver();
-        $self->redisUnavailable = IcingaRedis::isUnavailable();
+        $self->redisUnavailable = Backend::getRedis()->isUnavailable();
 
         return $self;
     }

--- a/test/php/library/Icingadb/Model/Behavior/FlattenedObjectVarsTest.php
+++ b/test/php/library/Icingadb/Model/Behavior/FlattenedObjectVarsTest.php
@@ -4,6 +4,7 @@
 
 namespace Tests\Icinga\Modules\Icingadb\Model\Behavior;
 
+use Icinga\Module\Icingadb\Common\Backend;
 use Icinga\Module\Icingadb\Model\Host;
 use ipl\Sql\Connection;
 use ipl\Sql\Test\SqlAssertions;
@@ -101,6 +102,7 @@ SQL;
     public function setUp(): void
     {
         $this->connection = new TestConnection();
+        Backend::setDb($this->connection);
         $this->setUpSqlAssertions();
     }
 


### PR DESCRIPTION
Required for an upcoming change. Though, I wanted to change this already a long time ago.

There's absolutely no need to have several open connections to the same database. Which was the case before, since the connection was established for each user (class) of the `Database` trait.

But with PDO, queries are by default all serially processed. Only for MySQL it is possible to change this, by [disabling query buffering](https://www.php.net/manual/en/mysqlinfo.concepts.buffering.php).

But Icinga DB Web is incompatible anyway, with disabled query buffering, and so changing this to a singleton is fine in my opinion.

I've deliberately kept the `Database` trait, to not update all usages of it. In case only the connection is required, the trait still has its use.