### PR TITLE
Macros: Add missing support for `DateTime` type macro

### DIFF
--- a/library/Icingadb/Common/Macros.php
+++ b/library/Icingadb/Common/Macros.php
@@ -127,6 +127,6 @@ trait Macros
             $value = $value ? 'y' : 'n';
         }
 
-        return $value ?? $macro;
+        return (string) ($value ?? $macro);
     }
 }

--- a/library/Icingadb/Common/Macros.php
+++ b/library/Icingadb/Common/Macros.php
@@ -123,6 +123,8 @@ trait Macros
 
         if ($value instanceof DateTime) {
             $value = $value->format(DateTime::ATOM);
+        } elseif (is_bool($value)) {
+            $value = $value ? 'y' : 'n';
         }
 
         return $value ?? $macro;

--- a/library/Icingadb/Common/Macros.php
+++ b/library/Icingadb/Common/Macros.php
@@ -4,6 +4,7 @@
 
 namespace Icinga\Module\Icingadb\Common;
 
+use DateTime;
 use Icinga\Application\Logger;
 use Icinga\Module\Icingadb\Compat\CompatHost;
 use Icinga\Module\Icingadb\Compat\CompatService;
@@ -120,6 +121,10 @@ trait Macros
             $value = null;
         }
 
-        return $value !== null ? $value : $macro;
+        if ($value instanceof DateTime) {
+            $value = $value->format(DateTime::ATOM);
+        }
+
+        return $value ?? $macro;
     }
 }


### PR DESCRIPTION
fixes #1111