### PR TITLE
Rename users and usergroups to contacts and contactgroups

### DIFF
--- a/application/clicommands/MigrateCommand.php
+++ b/application/clicommands/MigrateCommand.php
@@ -357,7 +357,7 @@ class MigrateCommand extends Command
                         } elseif ($permission === 'no-monitoring/contacts') {
                             $changed = true;
                             $updatedPermissions[] = $permission;
-                            $role['icingadb/denylist/routes'] = 'contacts,usergroups';
+                            $role['icingadb/denylist/routes'] = 'contacts,contactgroups';
                         } else {
                             $updatedPermissions[] = $permission;
                         }

--- a/application/clicommands/MigrateCommand.php
+++ b/application/clicommands/MigrateCommand.php
@@ -357,7 +357,7 @@ class MigrateCommand extends Command
                         } elseif ($permission === 'no-monitoring/contacts') {
                             $changed = true;
                             $updatedPermissions[] = $permission;
-                            $role['icingadb/denylist/routes'] = 'users,usergroups';
+                            $role['icingadb/denylist/routes'] = 'contacts,usergroups';
                         } else {
                             $updatedPermissions[] = $permission;
                         }

--- a/application/controllers/ContactController.php
+++ b/application/controllers/ContactController.php
@@ -11,7 +11,7 @@ use Icinga\Module\Icingadb\Widget\Detail\ObjectHeader;
 use Icinga\Module\Icingadb\Widget\Detail\UserDetail;
 use ipl\Stdlib\Filter;
 
-class UserController extends Controller
+class ContactController extends Controller
 {
     /** @var User The user object */
     protected $user;
@@ -20,7 +20,7 @@ class UserController extends Controller
     {
         $this->assertRouteAccess('contacts');
 
-        $this->addTitleTab(t('User'));
+        $this->addTitleTab(t('Contact'));
 
         $name = $this->params->getRequired('name');
 
@@ -31,7 +31,7 @@ class UserController extends Controller
 
         $user = $query->first();
         if ($user === null) {
-            throw new NotFoundError(t('User not found'));
+            throw new NotFoundError(t('Contact not found'));
         }
 
         $this->user = $user;

--- a/application/controllers/ContactgroupController.php
+++ b/application/controllers/ContactgroupController.php
@@ -11,7 +11,7 @@ use Icinga\Module\Icingadb\Widget\Detail\ObjectHeader;
 use Icinga\Module\Icingadb\Widget\Detail\UsergroupDetail;
 use ipl\Stdlib\Filter;
 
-class UsergroupController extends Controller
+class ContactgroupController extends Controller
 {
     /** @var Usergroup The usergroup object */
     protected $usergroup;
@@ -20,7 +20,7 @@ class UsergroupController extends Controller
     {
         $this->assertRouteAccess('contactgroups');
 
-        $this->addTitleTab(t('User Group'));
+        $this->addTitleTab(t('Contact Group'));
 
         $name = $this->params->getRequired('name');
 
@@ -31,7 +31,7 @@ class UsergroupController extends Controller
 
         $usergroup = $query->first();
         if ($usergroup === null) {
-            throw new NotFoundError(t('User group not found'));
+            throw new NotFoundError(t('Contact group not found'));
         }
 
         $this->usergroup = $usergroup;

--- a/application/controllers/ContactgroupsController.php
+++ b/application/controllers/ContactgroupsController.php
@@ -14,7 +14,7 @@ use ipl\Web\Control\LimitControl;
 use ipl\Web\Control\SortControl;
 use ipl\Web\Url;
 
-class UsergroupsController extends Controller
+class ContactgroupsController extends Controller
 {
     public function init()
     {
@@ -25,7 +25,7 @@ class UsergroupsController extends Controller
 
     public function indexAction()
     {
-        $this->addTitleTab(t('User Groups'));
+        $this->addTitleTab(t('Contact Groups'));
 
         $db = $this->getDb();
 

--- a/application/controllers/ContactsController.php
+++ b/application/controllers/ContactsController.php
@@ -12,9 +12,8 @@ use Icinga\Module\Icingadb\Widget\ItemList\ObjectList;
 use Icinga\Module\Icingadb\Web\Control\ViewModeSwitcher;
 use ipl\Web\Control\LimitControl;
 use ipl\Web\Control\SortControl;
-use ipl\Web\Url;
 
-class UsersController extends Controller
+class ContactsController extends Controller
 {
     public function init()
     {
@@ -25,7 +24,7 @@ class UsersController extends Controller
 
     public function indexAction()
     {
-        $this->addTitleTab(t('Users'));
+        $this->addTitleTab(t('Contacts'));
 
         $db = $this->getDb();
 

--- a/application/controllers/UserController.php
+++ b/application/controllers/UserController.php
@@ -1,0 +1,28 @@
+<?php
+
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+
+namespace Icinga\Module\Icingadb\Controllers;
+
+use Icinga\Module\Icingadb\Web\Controller;
+
+/**
+ * @deprecated Will be removed with 1.3, use ContactController instead
+ */
+class UserController extends Controller
+{
+    public function preDispatch()
+    {
+        $url = $this->getRequest()->getUrl();
+        $url->setPath(preg_replace(
+            '~^icingadb/user(?=/|$)~',
+            'icingadb/contact',
+            $url->getPath()
+        ));
+
+        $this->getResponse()
+            ->setHttpResponseCode(301)
+            ->setHeader('Location', $url->getAbsoluteUrl())
+            ->sendResponse();
+    }
+}

--- a/application/controllers/UserController.php
+++ b/application/controllers/UserController.php
@@ -18,7 +18,7 @@ class UserController extends Controller
 
     public function init()
     {
-        $this->assertRouteAccess('users');
+        $this->assertRouteAccess('contacts');
 
         $this->addTitleTab(t('User'));
 

--- a/application/controllers/UsergroupController.php
+++ b/application/controllers/UsergroupController.php
@@ -18,7 +18,7 @@ class UsergroupController extends Controller
 
     public function init()
     {
-        $this->assertRouteAccess('usergroups');
+        $this->assertRouteAccess('contactgroups');
 
         $this->addTitleTab(t('User Group'));
 

--- a/application/controllers/UsergroupController.php
+++ b/application/controllers/UsergroupController.php
@@ -1,0 +1,28 @@
+<?php
+
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+
+namespace Icinga\Module\Icingadb\Controllers;
+
+use Icinga\Module\Icingadb\Web\Controller;
+
+/**
+ * @deprecated Will be removed with 1.3, use ContactgroupController instead
+ */
+class UsergroupController extends Controller
+{
+    public function preDispatch()
+    {
+        $url = $this->getRequest()->getUrl();
+        $url->setPath(preg_replace(
+            '~^icingadb/usergroup(?=/|$)~',
+            'icingadb/contactgroup',
+            $url->getPath()
+        ));
+
+        $this->getResponse()
+            ->setHttpResponseCode(301)
+            ->setHeader('Location', $url->getAbsoluteUrl())
+            ->sendResponse();
+    }
+}

--- a/application/controllers/UsergroupsController.php
+++ b/application/controllers/UsergroupsController.php
@@ -1,0 +1,28 @@
+<?php
+
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+
+namespace Icinga\Module\Icingadb\Controllers;
+
+use Icinga\Module\Icingadb\Web\Controller;
+
+/**
+ * @deprecated Will be removed with 1.3, use ContactgroupsController instead
+ */
+class UsergroupsController extends Controller
+{
+    public function preDispatch()
+    {
+        $url = $this->getRequest()->getUrl();
+        $url->setPath(preg_replace(
+            '~^icingadb/usergroups(?=/|$)~',
+            'icingadb/contactgroups',
+            $url->getPath()
+        ));
+
+        $this->getResponse()
+            ->setHttpResponseCode(301)
+            ->setHeader('Location', $url->getAbsoluteUrl())
+            ->sendResponse();
+    }
+}

--- a/application/controllers/UsersController.php
+++ b/application/controllers/UsersController.php
@@ -1,0 +1,28 @@
+<?php
+
+/* Icinga DB Web | (c) 2025 Icinga GmbH | GPLv2 */
+
+namespace Icinga\Module\Icingadb\Controllers;
+
+use Icinga\Module\Icingadb\Web\Controller;
+
+/**
+ * @deprecated Will be removed with 1.3, use ContactsController instead
+ */
+class UsersController extends Controller
+{
+    public function preDispatch()
+    {
+        $url = $this->getRequest()->getUrl();
+        $url->setPath(preg_replace(
+            '~^icingadb/users(?=/|$)~',
+            'icingadb/contacts',
+            $url->getPath()
+        ));
+
+        $this->getResponse()
+            ->setHttpResponseCode(301)
+            ->setHeader('Location', $url->getAbsoluteUrl())
+            ->sendResponse();
+    }
+}

--- a/configuration.php
+++ b/configuration.php
@@ -373,10 +373,13 @@ namespace Icinga\Module\Icingadb {
             ]);
         }
 
-        if (! array_key_exists('usergroups', $routeDenylist)) {
-            $overviewSection->add(N_('User Groups'), [
-                'description' => $this->translate('List user groups'),
-                'url'         => 'icingadb/usergroups',
+        if (
+            ! array_key_exists('usergroups', $routeDenylist) // TODO: Remove with 1.3, compat only
+            && ! array_key_exists('contactgroups', $routeDenylist)
+        ) {
+            $overviewSection->add(N_('Contact Groups'), [
+                'description' => $this->translate('List contact groups'),
+                'url'         => 'icingadb/contactgroups',
                 'priority'    => 90,
                 'icon'        => 'users'
             ]);
@@ -502,11 +505,14 @@ namespace Icinga\Module\Icingadb {
             ]);
         }
 
-        if (! array_key_exists('usergroups', $routeDenylist)) {
-            $section->add(N_('User Groups'), [
-                'url'           => 'icingadb/usergroups',
+        if (
+            ! array_key_exists('usergroups', $routeDenylist) // TODO: Remove with 1.3, compat only
+            && ! array_key_exists('contactgroups', $routeDenylist)
+        ) {
+            $section->add(N_('Contact Groups'), [
+                'url'           => 'icingadb/contactgroups',
                 'priority'      => 70,
-                'description'   => $this->translate('List user groups'),
+                'description'   => $this->translate('List contact groups'),
                 'icon'          => 'users'
             ]);
         }

--- a/configuration.php
+++ b/configuration.php
@@ -382,16 +382,17 @@ namespace Icinga\Module\Icingadb {
             ]);
         }
 
-        if (! array_key_exists('users', $routeDenylist)) {
-            $overviewSection->add(N_('Users'), [
-                'description' => $this->translate('List users'),
-                'url'         => 'icingadb/users',
+        if (
+            ! array_key_exists('users', $routeDenylist) // TODO: Remove with 1.3, compat only
+            && ! array_key_exists('contacts', $routeDenylist)
+        ) {
+            $overviewSection->add(N_('Contacts'), [
+                'description' => $this->translate('List contacts'),
+                'url'         => 'icingadb/contacts',
                 'priority'    => 100,
                 'icon'        => 'user-friends'
             ]);
         }
-
-
 
         $overviewSection->add(N_('Comments'), [
             'url'         => 'icingadb/comments',
@@ -510,11 +511,14 @@ namespace Icinga\Module\Icingadb {
             ]);
         }
 
-        if (! array_key_exists('users', $routeDenylist)) {
-            $section->add(N_('Users'), [
-                'url'           => 'icingadb/users',
+        if (
+            ! array_key_exists('users', $routeDenylist) // TODO: Remove with 1.3, compat only
+            && ! array_key_exists('contacts', $routeDenylist)
+        ) {
+            $section->add(N_('Contacts'), [
+                'url'           => 'icingadb/contacts',
                 'priority'      => 80,
-                'description'   => $this->translate('List users'),
+                'description'   => $this->translate('List contacts'),
                 'icon'          => 'user-friends'
             ]);
         }

--- a/doc/04-Security.md
+++ b/doc/04-Security.md
@@ -77,7 +77,7 @@ icingadb/denylist/variables | Hide custom variables of Icinga objects that are p
 `icingadb/denylist/routes` will block users from accessing defined routes and from related information elsewhere.
 For example, if `hostgroups` are part of the list a user won't have access to the hostgroup overview nor to a host's
 groups shown in its detail area. This should be a comma separated list. Possible values are: hostgroups, servicegroups,
-users, usergroups
+contacts, usergroups
 
 `icingadb/denylist/variables` will block users from accessing certain custom variables. A user affected by this won't
 see that those variables even exist. This should be a comma separated list of [variable paths](#variable-paths). It is

--- a/doc/04-Security.md
+++ b/doc/04-Security.md
@@ -77,7 +77,7 @@ icingadb/denylist/variables | Hide custom variables of Icinga objects that are p
 `icingadb/denylist/routes` will block users from accessing defined routes and from related information elsewhere.
 For example, if `hostgroups` are part of the list a user won't have access to the hostgroup overview nor to a host's
 groups shown in its detail area. This should be a comma separated list. Possible values are: hostgroups, servicegroups,
-contacts, usergroups
+contacts, contactgroups
 
 `icingadb/denylist/variables` will block users from accessing certain custom variables. A user affected by this won't
 see that those variables even exist. This should be a comma separated list of [variable paths](#variable-paths). It is

--- a/doc/10-Migration.md
+++ b/doc/10-Migration.md
@@ -150,7 +150,7 @@ The command permissions have not changed. It is only the module identifier that 
 `monitoring/command/*` is now `icingadb/command/*`
 
 The `no-monitoring/contacts` permission (or *fake refusal*) is now a restriction: `icingadb/denylist/routes`.
-Add `contacts,usergroups` to it to achieve the same effect.
+Add `contacts,contactgroups` to it to achieve the same effect.
 
 ### Perform The Migration
 

--- a/doc/10-Migration.md
+++ b/doc/10-Migration.md
@@ -150,7 +150,7 @@ The command permissions have not changed. It is only the module identifier that 
 `monitoring/command/*` is now `icingadb/command/*`
 
 The `no-monitoring/contacts` permission (or *fake refusal*) is now a restriction: `icingadb/denylist/routes`.
-Add `users,usergroups` to it to achieve the same effect.
+Add `contacts,usergroups` to it to achieve the same effect.
 
 ### Perform The Migration
 

--- a/library/Icingadb/Common/Auth.php
+++ b/library/Icingadb/Common/Auth.php
@@ -44,6 +44,8 @@ trait Auth
         if (! array_key_exists($name, $routeDenylist)) {
             if ($name === 'contacts' && array_key_exists('users', $routeDenylist)) {
                 return false; // TODO: Remove with 1.3, compat only
+            } elseif ($name === 'contactgroups' && array_key_exists('usergroups', $routeDenylist)) {
+                return false; // TODO: Remove with 1.3, compat only
             }
 
             return true;

--- a/library/Icingadb/Common/Auth.php
+++ b/library/Icingadb/Common/Auth.php
@@ -41,7 +41,15 @@ trait Auth
             return StringHelper::trimSplit($restriction);
         }, $this->getAuth()->getRestrictions('icingadb/denylist/routes'))));
 
-        return ! array_key_exists($name, $routeDenylist);
+        if (! array_key_exists($name, $routeDenylist)) {
+            if ($name === 'contacts' && array_key_exists('users', $routeDenylist)) {
+                return false; // TODO: Remove with 1.3, compat only
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/library/Icingadb/Common/Links.php
+++ b/library/Icingadb/Common/Links.php
@@ -123,7 +123,7 @@ abstract class Links
 
     public static function usergroup(Usergroup $usergroup): Url
     {
-        return Url::fromPath('icingadb/usergroup', ['name' => $usergroup->name]);
+        return Url::fromPath('icingadb/contactgroup', ['name' => $usergroup->name]);
     }
 
     public static function users(): Url

--- a/library/Icingadb/Common/Links.php
+++ b/library/Icingadb/Common/Links.php
@@ -118,7 +118,7 @@ abstract class Links
 
     public static function user(User $user): Url
     {
-        return Url::fromPath('icingadb/user', ['name' => $user->name]);
+        return Url::fromPath('icingadb/contact', ['name' => $user->name]);
     }
 
     public static function usergroup(Usergroup $usergroup): Url

--- a/library/Icingadb/Common/Links.php
+++ b/library/Icingadb/Common/Links.php
@@ -133,7 +133,7 @@ abstract class Links
 
     public static function usergroups(): Url
     {
-        return Url::fromPath('icingadb/usergroups');
+        return Url::fromPath('icingadb/contactgroups');
     }
 
     public static function event(History $event): Url

--- a/library/Icingadb/Common/Links.php
+++ b/library/Icingadb/Common/Links.php
@@ -128,7 +128,7 @@ abstract class Links
 
     public static function users(): Url
     {
-        return Url::fromPath('icingadb/users');
+        return Url::fromPath('icingadb/contacts');
     }
 
     public static function usergroups(): Url

--- a/library/Icingadb/Compat/UrlMigrator.php
+++ b/library/Icingadb/Compat/UrlMigrator.php
@@ -32,7 +32,7 @@ class UrlMigrator
         'monitoring/list/hostgroups' => ['hostgroups', 'icingadb/hostgroups'],
         'monitoring/list/servicegroups' => ['servicegroups', 'icingadb/servicegroups'],
         'monitoring/list/contactgroups' => ['contactgroups', 'icingadb/usergroups'],
-        'monitoring/list/contacts' => ['contacts', 'icingadb/users'],
+        'monitoring/list/contacts' => ['contacts', 'icingadb/contacts'],
         'monitoring/list/comments' => ['comments', 'icingadb/comments'],
         'monitoring/list/downtimes' => ['downtimes', 'icingadb/downtimes'],
         'monitoring/list/eventhistory' => ['history', 'icingadb/history'],

--- a/library/Icingadb/Compat/UrlMigrator.php
+++ b/library/Icingadb/Compat/UrlMigrator.php
@@ -31,7 +31,7 @@ class UrlMigrator
         'monitoring/service/history' => ['service', 'icingadb/service/history'],
         'monitoring/list/hostgroups' => ['hostgroups', 'icingadb/hostgroups'],
         'monitoring/list/servicegroups' => ['servicegroups', 'icingadb/servicegroups'],
-        'monitoring/list/contactgroups' => ['contactgroups', 'icingadb/usergroups'],
+        'monitoring/list/contactgroups' => ['contactgroups', 'icingadb/contactgroups'],
         'monitoring/list/contacts' => ['contacts', 'icingadb/contacts'],
         'monitoring/list/comments' => ['comments', 'icingadb/comments'],
         'monitoring/list/downtimes' => ['downtimes', 'icingadb/downtimes'],

--- a/library/Icingadb/Model/NotificationHistory.php
+++ b/library/Icingadb/Model/NotificationHistory.php
@@ -80,7 +80,7 @@ class NotificationHistory extends Model
             'previous_hard_state'   => t('Previous Hard State'),
             'author'                => t('Notification Author'),
             'text'                  => t('Notification Text'),
-            'users_notified'        => t('Users Notified')
+            'users_notified'        => t('Contacts Notified')
         ];
     }
 

--- a/library/Icingadb/Model/Usergroup.php
+++ b/library/Icingadb/Model/Usergroup.php
@@ -49,11 +49,11 @@ class Usergroup extends Model
     {
         return [
             'environment_id'        => t('Environment Id'),
-            'name_checksum'         => t('Usergroup Name Checksum'),
-            'properties_checksum'   => t('Usergroup Properties Checksum'),
-            'name'                  => t('Usergroup Name'),
-            'name_ci'               => t('Usergroup Name (CI)'),
-            'display_name'          => t('Usergroup Display Name'),
+            'name_checksum'         => t('Contactgroup Name Checksum'),
+            'properties_checksum'   => t('Contactgroup Properties Checksum'),
+            'name'                  => t('Contactgroup Name'),
+            'name_ci'               => t('Contactgroup Name (CI)'),
+            'display_name'          => t('Contactgroup Display Name'),
             'zone_id'               => t('Zone Id')
         ];
     }

--- a/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
+++ b/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
@@ -55,7 +55,7 @@ class ObjectSuggestions extends Suggestions
             'service'               => t('Service %s', '..<customvar-name>'),
             'servicegroup'          => t('Servicegroup %s', '..<customvar-name>'),
             'timeperiod'            => t('Timeperiod %s', '..<customvar-name>'),
-            'user'                  => t('User %s', '..<customvar-name>'),
+            'user'                  => t('Contact %s', '..<customvar-name>'),
             'usergroup'             => t('Usergroup %s', '..<customvar-name>')
         ];
     }

--- a/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
+++ b/library/Icingadb/Web/Control/SearchBar/ObjectSuggestions.php
@@ -56,7 +56,7 @@ class ObjectSuggestions extends Suggestions
             'servicegroup'          => t('Servicegroup %s', '..<customvar-name>'),
             'timeperiod'            => t('Timeperiod %s', '..<customvar-name>'),
             'user'                  => t('Contact %s', '..<customvar-name>'),
-            'usergroup'             => t('Usergroup %s', '..<customvar-name>')
+            'usergroup'             => t('Contactgroup %s', '..<customvar-name>')
         ];
     }
 

--- a/library/Icingadb/Widget/Detail/EventDetail.php
+++ b/library/Icingadb/Widget/Detail/EventDetail.php
@@ -152,14 +152,14 @@ class EventDetail extends BaseHtmlElement
         $eventInfo[] = new HorizontalKeyValue($objectKey, $objectInfo);
 
 
-        $notifiedUsers = [new HtmlElement('h2', null, Text::create(t('Notified Users')))];
+        $notifiedUsers = [new HtmlElement('h2', null, Text::create(t('Notified Contacts')))];
 
         if ($notification->users_notified === 0) {
             $notifiedUsers[] = new EmptyState(t('None', 'notified users: none'));
-        } elseif (! $this->isPermittedRoute('users')) {
+        } elseif (! $this->isPermittedRoute('contacts')) {
             $notifiedUsers[] = Text::create(sprintf(tp(
-                'This notification was sent to a single user',
-                'This notification was sent to %d users',
+                'This notification was sent to a single contact',
+                'This notification was sent to %d contacts',
                 $notification->users_notified
             ), $notification->users_notified));
         } elseif ($notification->users_notified > 0) {

--- a/library/Icingadb/Widget/Detail/ObjectDetail.php
+++ b/library/Icingadb/Widget/Detail/ObjectDetail.php
@@ -402,8 +402,8 @@ class ObjectDetail extends BaseHtmlElement
         return [
             Html::tag('h2', t('Notifications')),
             new HorizontalKeyValue(
-                t('Users'),
-                $userList->hasContent() ? $userList : new EmptyState(t('No users configured.'))
+                t('Contacts'),
+                $userList->hasContent() ? $userList : new EmptyState(t('No contacts configured.'))
             ),
             new HorizontalKeyValue(
                 t('User Groups'),
@@ -574,7 +574,7 @@ class ObjectDetail extends BaseHtmlElement
         }
 
         $userQuery = null;
-        if ($this->isPermittedRoute('users')) {
+        if ($this->isPermittedRoute('contacts')) {
             $userQuery = User::on($this->getDb());
             $userQuery->filter($objectFilter);
             $this->applyRestrictions($userQuery);

--- a/library/Icingadb/Widget/Detail/ObjectDetail.php
+++ b/library/Icingadb/Widget/Detail/ObjectDetail.php
@@ -406,10 +406,10 @@ class ObjectDetail extends BaseHtmlElement
                 $userList->hasContent() ? $userList : new EmptyState(t('No contacts configured.'))
             ),
             new HorizontalKeyValue(
-                t('User Groups'),
+                t('Contact Groups'),
                 $usergroupList->hasContent()
                     ? $usergroupList
-                    : new EmptyState(t('No user groups configured.'))
+                    : new EmptyState(t('No contact groups configured.'))
             )
         ];
     }
@@ -587,7 +587,7 @@ class ObjectDetail extends BaseHtmlElement
             }
         }
 
-        if ($this->isPermittedRoute('usergroups')) {
+        if ($this->isPermittedRoute('contactgroups')) {
             $usergroupQuery = Usergroup::on($this->getDb());
             $usergroupQuery->filter($objectFilter);
             $this->applyRestrictions($usergroupQuery);

--- a/library/Icingadb/Widget/Detail/UsergroupDetail.php
+++ b/library/Icingadb/Widget/Detail/UsergroupDetail.php
@@ -74,7 +74,7 @@ class UsergroupDetail extends BaseHtmlElement
         ))->setBaseTarget('_next');
 
         return [
-            new HtmlElement('h2', null, Text::create(t('Users'))),
+            new HtmlElement('h2', null, Text::create(t('Contacts'))),
             new ObjectList($users),
             $showMoreLink
         ];

--- a/library/Icingadb/Widget/ItemList/ObjectList.php
+++ b/library/Icingadb/Widget/ItemList/ObjectList.php
@@ -209,7 +209,7 @@ class ObjectList extends ItemList
 
             case $data instanceof User:
                 $this
-                    ->setDetailUrl(Url::fromPath('icingadb/user'))
+                    ->setDetailUrl(Url::fromPath('icingadb/contact'))
                     ->addDetailFilterAttribute($item, Filter::equal('name', $object->name));
 
                 break;

--- a/library/Icingadb/Widget/ItemList/ObjectList.php
+++ b/library/Icingadb/Widget/ItemList/ObjectList.php
@@ -215,7 +215,7 @@ class ObjectList extends ItemList
                 break;
             case $object instanceof Usergroup:
                 $this
-                    ->setDetailUrl(Url::fromPath('icingadb/usergroup'))
+                    ->setDetailUrl(Url::fromPath('icingadb/contactgroup'))
                     ->addDetailFilterAttribute($item, Filter::equal('name', $object->name));
 
                 break;

--- a/test/php/application/clicommands/MigrateCommandTest.php
+++ b/test/php/application/clicommands/MigrateCommandTest.php
@@ -499,7 +499,7 @@ class MigrateCommandTest extends TestCase
                 ],
                 'no-monitoring-contacts' => [
                     'permissions'               => 'module/monitoring,no-monitoring/contacts',
-                    'icingadb/denylist/routes'  => 'users,usergroups'
+                    'icingadb/denylist/routes'  => 'contacts,usergroups'
                 ],
                 'reporting-only' => [
                     'permissions'   => 'module/reporting'

--- a/test/php/application/clicommands/MigrateCommandTest.php
+++ b/test/php/application/clicommands/MigrateCommandTest.php
@@ -499,7 +499,7 @@ class MigrateCommandTest extends TestCase
                 ],
                 'no-monitoring-contacts' => [
                     'permissions'               => 'module/monitoring,no-monitoring/contacts',
-                    'icingadb/denylist/routes'  => 'contacts,usergroups'
+                    'icingadb/denylist/routes'  => 'contacts,contactgroups'
                 ],
                 'reporting-only' => [
                     'permissions'   => 'module/reporting'


### PR DESCRIPTION
This ensures that the UI will stop using the term *user* in favor of *contact* and the term *usergroup* in favor of *contactgroup*.
Routes and denylists will also change accordingly.

What does not change, are database table names. While it would be certainly possible, changing relation names is a breaking change I'd like to avoid. It would break any restriction on `<type>.user.name` and `<type>.usergroup.name`.

@flourish86 Please ensure the UI doesn't use the old terms anywhere.
@sukhwinder33445 Please ensure I did not forget anything related to routes and denylists.

closes #944