### PR TITLE
(Host|Service)Controller: Reset the query offset for LoadMore list

### DIFF
--- a/application/controllers/HostController.php
+++ b/application/controllers/HostController.php
@@ -157,6 +157,7 @@ class HostController extends Controller
         $page = $paginationControl->getCurrentPageNumber();
 
         if ($page > 1 && ! $compact) {
+            $history->resetOffset();
             $history->limit($page * $limitControl->getLimit());
         }
 

--- a/application/controllers/ServiceController.php
+++ b/application/controllers/ServiceController.php
@@ -303,6 +303,7 @@ class ServiceController extends Controller
         $page = $paginationControl->getCurrentPageNumber();
 
         if ($page > 1 && ! $compact) {
+            $history->resetOffset();
             $history->limit($page * $limitControl->getLimit());
         }
 


### PR DESCRIPTION
This change was missing in the https://github.com/Icinga/icingadb-web/pull/734


fixes https://github.com/Icinga/icingadb-web/issues/1164