### PR TITLE
`Delete(Downtime|Comment)Form`: Fix the incorrect success message

### DIFF
--- a/application/forms/Command/Object/DeleteCommentForm.php
+++ b/application/forms/Command/Object/DeleteCommentForm.php
@@ -27,7 +27,7 @@ class DeleteCommentForm extends CommandForm
             $countObjects = count($this->getObjects());
 
             Notification::success(sprintf(
-                tp('Removed comment successfully', 'Removed comment from %d objects successfully', $countObjects),
+                tp('Removed comment successfully', 'Removed %d comments successfully', $countObjects),
                 $countObjects
             ));
         });

--- a/application/forms/Command/Object/DeleteDowntimeForm.php
+++ b/application/forms/Command/Object/DeleteDowntimeForm.php
@@ -27,7 +27,7 @@ class DeleteDowntimeForm extends CommandForm
             $countObjects = count($this->getObjects());
 
             Notification::success(sprintf(
-                tp('Removed downtime successfully', 'Removed downtime from %d objects successfully', $countObjects),
+                tp('Removed downtime successfully', 'Removed %d downtimes successfully', $countObjects),
                 $countObjects
             ));
         });


### PR DESCRIPTION
fixes #1181 