### PR TITLE
Break the group names and display names

### DIFF
--- a/public/css/item/hostgroup.less
+++ b/public/css/item/hostgroup.less
@@ -4,10 +4,17 @@
       align-content: center; // Actually, not sure why this works… .col is not a grid container
     }
 
-    > .main > .caption {
-      height: auto;
-      .text-ellipsis();
-      .line-clamp("reset");
+    > .main {
+      > .caption {
+        height: auto;
+        white-space: normal;
+        word-break: break-word;
+      }
+
+      > header > .title > .subject {
+        white-space: normal;
+        word-break: break-word;
+      }
     }
   }
 


### PR DESCRIPTION
Break the names and display names of host and service groups instead of cutting them off.