### PR TITLE
Align `<i>` tag icon images correctly

### DIFF
--- a/library/Icingadb/View/BaseHostAndServiceRenderer.php
+++ b/library/Icingadb/View/BaseHostAndServiceRenderer.php
@@ -291,6 +291,10 @@ abstract class BaseHostAndServiceRenderer implements ItemRenderer
     {
         if ($name === 'icon-image') {
             if (isset($item->icon_image->icon_image)) {
+                if (str_contains($item->icon_image->icon_image, '.')) {
+                    $element->addAttributes(['class' => 'real-image']);
+                }
+
                 $element->addHtml(new IconImage($item->icon_image->icon_image, $item->icon_image_alt));
             }
 

--- a/public/css/item/icon-image.less
+++ b/public/css/item/icon-image.less
@@ -23,12 +23,16 @@
     .icon-image {
       height: 2em;
       width: 2em;
-      line-height: 2;
+
+      &.real-image {
+        line-height: 2;
+      }
     }
   }
 
   &.header-item-layout .icon-image {
     margin-top: 0;
+    line-height: 2;
 
     img {
       vertical-align: middle;


### PR DESCRIPTION
If icon image is a real image and no `i` tag set `line-height: 2`. If the icon image is in a detail header always set `line-height: 2`. Otherwise normal icons with an `i` tag would be misaligned.