### PR TITLE
Verify notifications integration

### DIFF
--- a/library/Icingadb/ProvidedHook/ApplicationState.php
+++ b/library/Icingadb/ProvidedHook/ApplicationState.php
@@ -7,32 +7,38 @@ namespace Icinga\Module\Icingadb\ProvidedHook;
 
 use Exception;
 use Icinga\Application\Hook\ApplicationStateHook;
+use Icinga\Module\Icingadb\Common\Auth;
 use Icinga\Module\Icingadb\Common\Database;
 use Icinga\Module\Icingadb\Common\IcingaRedis;
 use Icinga\Module\Icingadb\Model\Instance;
 use Icinga\Web\Session;
+use ipl\I18n\Translation;
 use ipl\Stdlib\Filter;
 
 class ApplicationState extends ApplicationStateHook
 {
+    use Auth;
     use Database;
+    use Translation;
 
     public function collectMessages()
     {
+        $session = Session::getSession()->getNamespace('icingadb');
+
         try {
             $lastIcingaHeartbeat = IcingaRedis::getLastIcingaHeartbeat();
         } catch (Exception $e) {
-            $downSince = Session::getSession()->getNamespace('icingadb')->get('redis.down-since');
+            $downSince = $session->get('redis.down-since');
 
             if ($downSince === null) {
                 $downSince = time();
-                Session::getSession()->getNamespace('icingadb')->set('redis.down-since', $downSince);
+                $session->set('redis.down-since', $downSince);
             }
 
             $this->addError(
                 'icingadb/redis-down',
                 $downSince,
-                sprintf(t("Can't connect to Redis: %s"), $e->getMessage())
+                sprintf($this->translate("Can't connect to Redis: %s"), $e->getMessage())
             );
 
             return;
@@ -45,19 +51,17 @@ class ApplicationState extends ApplicationStateHook
             ->first();
 
         if ($instance === null) {
-            $noInstanceSince = Session::getSession()
-                ->getNamespace('icingadb')->get('icingadb.no-instance-since');
+            $noInstanceSince = $session->get('icingadb.no-instance-since');
 
             if ($noInstanceSince === null) {
                 $noInstanceSince = time();
-                Session::getSession()
-                    ->getNamespace('icingadb')->set('icingadb.no-instance-since', $noInstanceSince);
+                $session->set('icingadb.no-instance-since', $noInstanceSince);
             }
 
             $this->addError(
                 'icingadb/no-instance',
                 $noInstanceSince,
-                t(
+                $this->translate(
                     'It seems that Icinga DB is not running.'
                     . ' Make sure Icinga DB is running and writing into the database.'
                 )
@@ -65,48 +69,41 @@ class ApplicationState extends ApplicationStateHook
 
             return;
         } else {
-            Session::getSession()->getNamespace('icingadb')->delete('db.no-instance-since');
+            $session->delete('db.no-instance-since');
         }
 
         $outdatedDbHeartbeat = $instance->heartbeat->getTimestamp() < time() - 60;
 
         if ($lastIcingaHeartbeat === null) {
-            $missingSince = Session::getSession()
-                ->getNamespace('icingadb')->get('redis.heartbeat-missing-since');
+            $missingSince = $session->get('redis.heartbeat-missing-since');
 
             if ($missingSince === null) {
                 $missingSince = time();
-                Session::getSession()
-                    ->getNamespace('icingadb')->set('redis.heartbeat-missing-since', $missingSince);
+                $session->set('redis.heartbeat-missing-since', $missingSince);
             }
 
             $lastIcingaHeartbeat = $missingSince;
         } else {
-            Session::getSession()->getNamespace('icingadb')->delete('redis.heartbeat-missing-since');
+            $session->delete('redis.heartbeat-missing-since');
         }
 
-        switch (true) {
-            case $outdatedDbHeartbeat && $instance->heartbeat->getTimestamp() > $lastIcingaHeartbeat:
-                $this->addError(
-                    'icingadb/redis-outdated',
-                    $lastIcingaHeartbeat,
-                    t('Redis is outdated. Make sure Icinga 2 is running and connected to Redis.')
-                );
-
-                break;
-            case $outdatedDbHeartbeat:
-                $this->addError(
-                    'icingadb/icingadb-down',
-                    $instance->heartbeat->getTimestamp(),
-                    t(
-                        'It seems that Icinga DB is not running.'
-                        . ' Make sure Icinga DB is running and writing into the database.'
-                    )
-                );
-
-                break;
+        if ($outdatedDbHeartbeat && $instance->heartbeat->getTimestamp() > $lastIcingaHeartbeat) {
+            $this->addError(
+                'icingadb/redis-outdated',
+                $lastIcingaHeartbeat,
+                $this->translate('Redis is outdated. Make sure Icinga 2 is running and connected to Redis.')
+            );
+        } elseif ($outdatedDbHeartbeat) {
+            $this->addError(
+                'icingadb/icingadb-down',
+                $instance->heartbeat->getTimestamp(),
+                $this->translate(
+                    'It seems that Icinga DB is not running.'
+                    . ' Make sure Icinga DB is running and writing into the database.'
+                )
+            );
         }
 
-        Session::getSession()->getNamespace('icingadb')->delete('redis.down-since');
+        $session->delete('redis.down-since');
     }
 }

--- a/library/Icingadb/ProvidedHook/ApplicationState.php
+++ b/library/Icingadb/ProvidedHook/ApplicationState.php
@@ -105,5 +105,33 @@ class ApplicationState extends ApplicationStateHook
         }
 
         $session->delete('redis.down-since');
+
+        if (isset($instance->notifications_healthy) && ! $instance->notifications_healthy) {
+            if (
+                ! $this->getAuth()->hasPermission('icingadb/notifications/manage')
+                && ! $this->getAuth()->hasPermission('icingadb/notifications/subscribe')
+            ) {
+                // Do not show this error to users who do not rely on it
+
+                return;
+            }
+
+            $unhealthySince = $session->get('notifications.unhealthy-since');
+            if ($unhealthySince === null) {
+                $unhealthySince = time();
+                $session->set('notifications.unhealthy-since', $unhealthySince);
+            }
+
+            $this->addError(
+                'icingadb/notifications-unhealthy',
+                $unhealthySince,
+                $this->translate(
+                    'Notification transmission has been interrupted.'
+                    . ' Make sure Icinga DB is able to connect to Icinga Notifications.'
+                )
+            );
+        } else {
+            $session->delete('notifications.unhealthy-since');
+        }
     }
 }

--- a/library/Icingadb/ProvidedHook/IcingaHealth.php
+++ b/library/Icingadb/ProvidedHook/IcingaHealth.php
@@ -9,11 +9,13 @@ use Icinga\Application\Hook\HealthHook;
 use Icinga\Module\Icingadb\Common\Backend;
 use Icinga\Module\Icingadb\Common\Database;
 use Icinga\Module\Icingadb\Model\Instance;
+use ipl\I18n\Translation;
 use ipl\Web\Url;
 
 class IcingaHealth extends HealthHook
 {
     use Database;
+    use Translation;
 
     public const REQUIRED_ICINGADB_VERSION = '1.4.0';
 
@@ -54,13 +56,13 @@ class IcingaHealth extends HealthHook
 
         if ($instance === null) {
             $this->setState(self::STATE_UNKNOWN);
-            $this->setMessage(t(
+            $this->setMessage($this->translate(
                 'Icinga DB is not running or not writing into the database'
                 . ' (make sure the icinga feature "icingadb" is enabled)'
             ));
         } elseif ($instance->heartbeat->getTimestamp() < time() - 60) {
             $this->setState(self::STATE_CRITICAL);
-            $this->setMessage(t(
+            $this->setMessage($this->translate(
                 'Icinga DB is not running or not writing into the database'
                 . ' (make sure the icinga feature "icingadb" is enabled)'
             ));
@@ -74,7 +76,7 @@ class IcingaHealth extends HealthHook
         ) {
             $this->setState(self::STATE_CRITICAL);
             $this->setMessage(sprintf(
-                t('Icinga DB is outdated, please upgrade to version %s or later.'),
+                $this->translate('Icinga DB is outdated, please upgrade to version %s or later.'),
                 self::REQUIRED_ICINGADB_VERSION
             ));
         } else {
@@ -83,24 +85,24 @@ class IcingaHealth extends HealthHook
 
             if (! $instance->icinga2_active_host_checks_enabled) {
                 $this->setState(self::STATE_WARNING);
-                $warningMessages[] = t('Active host checks are disabled');
+                $warningMessages[] = $this->translate('Active host checks are disabled');
             }
 
             if (! $instance->icinga2_active_service_checks_enabled) {
                 $this->setState(self::STATE_WARNING);
-                $warningMessages[] = t('Active service checks are disabled');
+                $warningMessages[] = $this->translate('Active service checks are disabled');
             }
 
             if (! $instance->icinga2_notifications_enabled) {
                 $this->setState(self::STATE_WARNING);
-                $warningMessages[] = t('Notifications are disabled');
+                $warningMessages[] = $this->translate('Notifications are disabled');
             }
 
             if ($this->getState() === self::STATE_WARNING) {
                 $this->setMessage(implode("; ", $warningMessages));
             } else {
                 $this->setMessage(sprintf(
-                    t('Icinga DB is running and writing into the database. (Version: %s)'),
+                    $this->translate('Icinga DB is running and writing into the database. (Version: %s)'),
                     $instance->icingadb_version
                 ));
             }

--- a/library/Icingadb/ProvidedHook/IcingaHealth.php
+++ b/library/Icingadb/ProvidedHook/IcingaHealth.php
@@ -6,6 +6,7 @@
 namespace Icinga\Module\Icingadb\ProvidedHook;
 
 use Icinga\Application\Hook\HealthHook;
+use Icinga\Module\Icingadb\Common\Auth;
 use Icinga\Module\Icingadb\Common\Backend;
 use Icinga\Module\Icingadb\Common\Database;
 use Icinga\Module\Icingadb\Model\Instance;
@@ -14,6 +15,7 @@ use ipl\Web\Url;
 
 class IcingaHealth extends HealthHook
 {
+    use Auth;
     use Database;
     use Translation;
 
@@ -79,6 +81,19 @@ class IcingaHealth extends HealthHook
                 $this->translate('Icinga DB is outdated, please upgrade to version %s or later.'),
                 self::REQUIRED_ICINGADB_VERSION
             ));
+        } elseif (
+            isset($instance->notifications_healthy)
+            && ! $instance->notifications_healthy
+            && (
+                $this->getAuth()->hasPermission('icingadb/notifications/manage')
+                || $this->getAuth()->hasPermission('icingadb/notifications/subscribe')
+            )
+        ) {
+            $this->setState(self::STATE_CRITICAL);
+            $this->setMessage($this->translate(
+                'Notification transmission has been interrupted.'
+                . ' Make sure Icinga DB is able to connect to Icinga Notifications.'
+            ));
         } else {
             $this->setState(self::STATE_OK);
             $warningMessages = [];
@@ -121,6 +136,7 @@ class IcingaHealth extends HealthHook
                 'icinga2_start_time' => $instance->icinga2_start_time->getTimestamp(),
                 'icinga2_version' => $instance->icinga2_version,
                 'icingadb_version' => $instance->icingadb_version ?? null,
+                'notifications_healthy' => $instance->notifications_healthy ?? null,
                 'endpoint' => ['name' => $instance->endpoint->name]
             ]);
         }
@@ -151,6 +167,10 @@ class IcingaHealth extends HealthHook
                 ]);
             if (Backend::supportsDependencies()) {
                 $query->withColumns('icingadb_version');
+            }
+
+            if (Backend::supportsNotifications()) {
+                $query->withColumns('notifications_healthy');
             }
 
             $this->instance = $query->first();

--- a/library/Icingadb/Widget/Health.php
+++ b/library/Icingadb/Widget/Health.php
@@ -8,12 +8,15 @@ namespace Icinga\Module\Icingadb\Widget;
 use Icinga\Module\Icingadb\ProvidedHook\IcingaHealth;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\Html;
+use ipl\I18n\Translation;
 use ipl\Web\Widget\TimeAgo;
 use ipl\Web\Widget\TimeSince;
 use ipl\Web\Widget\VerticalKeyValue;
 
 class Health extends BaseHtmlElement
 {
+    use Translation;
+
     protected $data;
 
     protected $tag = 'section';
@@ -35,21 +38,21 @@ class Health extends BaseHtmlElement
         ) {
             $this->addHtml(Html::tag('div', ['class' => 'icinga-health down'], [
                 sprintf(
-                    t('Icinga DB is outdated, please upgrade to version %s or later.'),
+                    $this->translate('Icinga DB is outdated, please upgrade to version %s or later.'),
                     IcingaHealth::REQUIRED_ICINGADB_VERSION
                 )
             ]));
         } elseif ($this->data->heartbeat->getTimestamp() > time() - 60) {
             $this->add(Html::tag('div', ['class' => 'icinga-health up'], [
                 Html::sprintf(
-                    t('Icinga 2 is up and running %s', '...since <timespan>'),
+                    $this->translate('Icinga 2 is up and running %s', '...since <timespan>'),
                     new TimeSince($this->data->icinga2_start_time->getTimestamp())
                 )
             ]));
         } else {
             $this->add(Html::tag('div', ['class' => 'icinga-health down'], [
                 Html::sprintf(
-                    t('Icinga 2 or Icinga DB is not running %s', '...since <timespan>'),
+                    $this->translate('Icinga 2 or Icinga DB is not running %s', '...since <timespan>'),
                     new TimeSince($this->data->heartbeat->getTimestamp())
                 )
             ]));
@@ -57,27 +60,27 @@ class Health extends BaseHtmlElement
 
         $icingaInfo = Html::tag('div', ['class' => 'icinga-info'], [
             new VerticalKeyValue(
-                t('Icinga 2 Version'),
+                $this->translate('Icinga 2 Version'),
                 $this->data->icinga2_version
             ),
             new VerticalKeyValue(
-                t('Icinga 2 Start Time'),
+                $this->translate('Icinga 2 Start Time'),
                 new TimeAgo($this->data->icinga2_start_time->getTimestamp())
             ),
             new VerticalKeyValue(
-                t('Last Heartbeat'),
+                $this->translate('Last Heartbeat'),
                 new TimeAgo($this->data->heartbeat->getTimestamp())
             ),
             new VerticalKeyValue(
-                t('Active Icinga 2 Endpoint'),
+                $this->translate('Active Icinga 2 Endpoint'),
                 $this->data->endpoint->name ?: t('N/A')
             ),
             new VerticalKeyValue(
-                t('Icinga DB Version'),
+                $this->translate('Icinga DB Version'),
                 $this->data->icingadb_version ?? t('N/A')
             ),
             new VerticalKeyValue(
-                t('Active Icinga Web Endpoint'),
+                $this->translate('Active Icinga Web Endpoint'),
                 gethostname() ?: t('N/A')
             )
         ]);

--- a/library/Icingadb/Widget/Health.php
+++ b/library/Icingadb/Widget/Health.php
@@ -5,6 +5,7 @@
 
 namespace Icinga\Module\Icingadb\Widget;
 
+use Icinga\Module\Icingadb\Common\Auth;
 use Icinga\Module\Icingadb\ProvidedHook\IcingaHealth;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\Html;
@@ -15,6 +16,7 @@ use ipl\Web\Widget\VerticalKeyValue;
 
 class Health extends BaseHtmlElement
 {
+    use Auth;
     use Translation;
 
     protected $data;
@@ -40,6 +42,20 @@ class Health extends BaseHtmlElement
                 sprintf(
                     $this->translate('Icinga DB is outdated, please upgrade to version %s or later.'),
                     IcingaHealth::REQUIRED_ICINGADB_VERSION
+                )
+            ]));
+        } elseif (
+            isset($this->data->notifications_healthy)
+            && ! $this->data->notifications_healthy
+            &&  (
+                $this->getAuth()->hasPermission('icingadb/notifications/manage')
+                || $this->getAuth()->hasPermission('icingadb/notifications/subscribe')
+            )
+        ) {
+            $this->addHtml(Html::tag('div', ['class' => 'icinga-health down'], [
+                $this->translate(
+                    'Notification transmission has been interrupted.'
+                    . ' Make sure Icinga DB is able to connect to Icinga Notifications.'
                 )
             ]));
         } elseif ($this->data->heartbeat->getTimestamp() > time() - 60) {
@@ -82,7 +98,13 @@ class Health extends BaseHtmlElement
             new VerticalKeyValue(
                 $this->translate('Active Icinga Web Endpoint'),
                 gethostname() ?: t('N/A')
-            )
+            ),
+            isset($this->data->notifications_healthy) ? new VerticalKeyValue(
+                $this->translate('Icinga Notifications Connection'),
+                $this->data->notifications_healthy
+                    ? $this->translate('Healthy')
+                    : $this->translate('Unhealthy')
+            ) : null
         ]);
         $this->add($icingaInfo);
     }


### PR DESCRIPTION
Extends the `\Icinga\Module\Icingadb\ProvidedHook\ApplicationState` hook to also show an error in case `icingadb_instance.notifications_healthy` is false. The health check and its detail also show the same information. Users who are not granted either `icingadb/notifications/manage` or `icingadb/notifications/subscribe` won't see it.

<img width="1114" height="697" alt="image" src="https://github.com/user-attachments/assets/35550beb-9aa0-48cf-bbc4-bba642926661" />

resolves #1410